### PR TITLE
Flatten configs to avoid json in json

### DIFF
--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -9,8 +9,9 @@ edition = "2021"
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive", "env"] }
 reqwest = { version = "0.11", features = ["json"] }
-exp2 = { git="https://github.com/mycelial/pipexperiments", rev="6d9689f2d425aa4593588bf2933753586f7707f9" }
-#exp2 = { path = "../../pipexperiments/exp2" }
+exp2 = { git="https://github.com/mycelial/pipexperiments", rev="6259cd83a2b0e32b6b8624e0f86e29a5889086b3" }
+# exp2 = { path = "../../pipexperiments/exp2" }
 anyhow = "1"
 base64 = { version = "0.21" }
 serde = { version = "1", features = ["derive"]}
+serde_json = "1"

--- a/myc-console/components/Flow/index.tsx
+++ b/myc-console/components/Flow/index.tsx
@@ -398,12 +398,7 @@ function Flow() {
         })
       }
 
-      configs.push({
-        "id": configId,
-        "raw_config": JSON.stringify({
-          section: section
-        })
-      });
+      configs.push({ "id": configId, "pipe": section });
 
       // console.log(sourceNode?.data, targetNode?.data);
     }

--- a/server/misc/set_pipe_configs.sh
+++ b/server/misc/set_pipe_configs.sh
@@ -2,5 +2,7 @@
 curl -v \
     -XPOST \
     --header "Content-Type: application/json" \
-    --data '{"configs":[{"id":1, "raw_config": "{\"section\":[{\"name\": \"sqlite\", \"path\": \"/tmp/test.sqlite\", \"query\": \"select * from test\"},{\"endpoint\":\"http://localhost:8080/ingestion\",\"name\":\"mycelial_net\",\"token\":\"mycelial_net_token\"}]}"}]}' \
+    --data '{"configs":[{"id":1, "pipe": {"section": [{"name": "sqlite", "path": "/tmp/test.sqlite", "query": "select * from test"},{"endpoint":"http://localhost:8080/ingestion","name":"mycelial_net","token":"mycelial_net_token"}]}}]}' \
     http://localhost:8080/pipe/configs
+
+echo


### PR DESCRIPTION
Updates dynamic section config, which no longer needs to store raw string and allowing our frontend to avoid extra jsonification.

Before:
```json
{
    "configs": [{
        "id":1,
        "raw_config": "{\"section\":[{\"name\": \"sqlite\", ...},{\"name\":\"mycelial_net\"...}]}"
    }]
}
``` 

After:
```json
{
    "configs": [{
        "id":1, 
        "pipe": {
            "section": [
                {"name": "sqlite", ...},
                {"name": "mycelial_net", ...}
            ]
        }
    }
]}
```
`raw_config` key was also renamed into `pipe`