### PR TITLE
Add ability to set database path

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -8,7 +8,9 @@ all:
 
 .PHONY: dev
 dev:
-	cargo-watch -q -c -s 'cargo run -- --token="foobar"'
+	cargo-watch -q -c \
+		-i mycelial.db \
+		-s 'cargo run -- --token="foobar"'
 
 .PHONY: vendor
 vendor:

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sqlx::{sqlite::SqliteConnectOptions, ConnectOptions, Row, SqliteConnection};
 use tower_http::services::ServeDir;
-use std::net::SocketAddr;
+use std::{net::SocketAddr, path::Path};
 use std::{str::FromStr, sync::Arc};
 use tokio::sync::Mutex;
 use uuid::Uuid;
@@ -35,6 +35,10 @@ struct CLI {
     /// Assets dir
     #[clap(short, long, env = "ASSETS_DIR")]
     assets_dir: String,
+
+    /// Database path
+    #[clap(short, long, env = "DATABASE_PATH", default_value = "mycelial.db")]
+    database_path: String
 }
 
 // FIXME: full body accumulation
@@ -200,11 +204,7 @@ pub struct Database {
 }
 
 impl Database {
-    async fn new(database_dir: &str) -> Result<Self, error::Error> {
-        let database_path = std::path::Path::new(database_dir)
-            .join("mycelial.db")
-            .to_string_lossy()
-            .to_string();
+    async fn new(database_path: &str) -> Result<Self, error::Error> {
         let database_url = format!("sqlite://{database_path}");
         let mut connection = SqliteConnectOptions::from_str(database_url.as_str())?
             .create_if_missing(true)
@@ -213,7 +213,7 @@ impl Database {
         sqlx::migrate!().run(&mut connection).await?;
         Ok(Self {
             connection: Arc::new(Mutex::new(connection)),
-            database_path,
+            database_path: database_path.into(),
         })
     }
 
@@ -349,11 +349,14 @@ impl App {
 
 impl App {
     pub async fn new(
-        database_dir: impl AsRef<str>,
+        db_path: impl AsRef<str>,
         token: impl Into<String>,
     ) -> anyhow::Result<Self> {
-        tokio::fs::create_dir_all(database_dir.as_ref()).await?;
-        let database = Database::new(database_dir.as_ref()).await?;
+        let db_path: &str = db_path.as_ref();
+        if let Some(parent) = Path::new(db_path).parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        };
+        let database = Database::new(db_path).await?;
         Ok(Self {
             database,
             token: token.into(),
@@ -372,7 +375,7 @@ impl App {
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = CLI::try_parse()?;
-    let app = App::new("", cli.token).await?;
+    let app = App::new(cli.database_path, cli.token).await?;
     let state = Arc::new(app);
 
     // FIXME: consistent endpoint namings


### PR DESCRIPTION
Adds usage of `DATABASE_PATH` env variable, which is already set in flyio.toml config.
Fixes issue of database persistence between deployments.