### PR TITLE
Add client registration/provisioning/showing in UI/token auth

### DIFF
--- a/myc-console/components/@types/client.d.ts
+++ b/myc-console/components/@types/client.d.ts
@@ -1,0 +1,8 @@
+export interface IClient {
+    id: string;
+}
+
+export type ClientContextType = {
+    clients: Array<IClient>;
+    token: string;
+};

--- a/myc-console/components/context/clientContext.tsx
+++ b/myc-console/components/context/clientContext.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import * as React from "react";
+import { ClientContextType, IClient } from "../@types/client";
+
+export const ClientContext = React.createContext<ClientContextType | null>(
+  null
+);
+
+async function getClients(token: string) {
+  try {
+    const response = await fetch("/api/clients", {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Authorization": "Bearer " + btoa(token),
+      },
+    });
+    const result = await response.json();
+    return result;
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+async function registerClient() {
+  try {
+    const response = await fetch("/api/client", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ id: "ui" }),
+    });
+    const result = await response.json();
+    return result;
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+async function getToken() {
+  try {
+    const response = await fetch("/api/tokens", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ client_id: "ui" }),
+    });
+    const result = await response.json();
+    return result;
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+async function registerClientAndGetToken() {
+  return registerClient()
+    .then((result) => {
+      getToken().then((result) => {
+        return result.id;
+      });
+    })
+    .catch((error) => {
+      console.error(error);
+      return "error";
+    });
+}
+
+const ClientProvider: React.FC<React.PropsWithChildren> = ({ children }) => {
+  const [clients, setClients] = React.useState<IClient[]>([
+    {
+      id: "post 1",
+    },
+    {
+      id: "post 2",
+    },
+  ]);
+
+  const [token, setToken] = React.useState<string>("");
+
+  React.useEffect(() => {
+    registerClientAndGetToken().then((result) => {
+      if (result) {
+        setToken(result);
+      }
+    });
+  }, []);
+
+  React.useEffect(() => {
+    getClients(token).then((result) => {
+      setClients(result.clients);
+    });
+  }, [token]);
+
+  return (
+    <ClientContext.Provider value={{ clients, token }}>
+      {children}
+    </ClientContext.Provider>
+  );
+};
+
+export default ClientProvider;

--- a/myc-console/components/nodes.tsx
+++ b/myc-console/components/nodes.tsx
@@ -1,17 +1,21 @@
-import { memo, FC, useEffect, useCallback } from 'react';
+import { memo, FC, useEffect, useContext, useCallback } from 'react';
 import { Handle, Position, NodeProps, NodeResizer, useNodeId, useReactFlow } from 'reactflow';
 
 import { Select, MultiSelect, Textarea, TextInput } from '@/components/inputs';
 
 import styles from '@/components/Flow/Flow.module.css';
+import { ClientContext } from './context/clientContext';
+import { ClientContextType } from './@types/client';
 
 
 const SqliteSourceNode: FC<NodeProps> = memo(({ id, data }) => {
   const instance = useReactFlow();
+  const { clients } = useContext(ClientContext) as ClientContextType;
 
   let initialValues = {
     databasePath: data.path ? data.path : "/tmp/test.sqlite",
-    sqlQuery: data.query ? data.query : "select * from test;"
+    sqlQuery: data.query ? data.query : "select * from test;",
+    client: data.client ? data.client : "",
   };
 
   const handleChange = useCallback((name: string, value: string) => {
@@ -30,12 +34,14 @@ const SqliteSourceNode: FC<NodeProps> = memo(({ id, data }) => {
   useEffect(() => {
     handleChange("path", initialValues.databasePath);
     handleChange("query", initialValues.sqlQuery);
+    handleChange("client", initialValues.client);
   }, [id]);
 
   return (
     <div className={styles.customNode}>
       <TextInput
-        label="SQLite Database Path"
+        name="sqliteDatabasePath"
+        label="Sqlite Database Path"
         placeholder={initialValues.databasePath}
         defaultValue={initialValues.databasePath}
         onChange={(event) => handleChange("path", event.currentTarget.value)}
@@ -46,7 +52,17 @@ const SqliteSourceNode: FC<NodeProps> = memo(({ id, data }) => {
         placeholder={initialValues.sqlQuery}
         defaultValue={initialValues.sqlQuery}
         onChange={(event) => handleChange("query", event.currentTarget.value)}
+      />
+      <Select
         className="nodrag"
+        label="Client"
+        placeholder="Pick one"
+        defaultValue={initialValues.client}
+        searchable
+        nothingFound="No options"
+        data={(clients || []).map(c => c.id)}
+        onChange={(value) => handleChange("client", value || "")}
+        withinPortal
       />
       <Handle type="source" position={Position.Right} id={id} />
     </div>
@@ -55,6 +71,7 @@ const SqliteSourceNode: FC<NodeProps> = memo(({ id, data }) => {
 
 const MycelialNetworkNode: FC<NodeProps> = memo(({ id, data }) => {
   const instance = useReactFlow();
+  const { clients } = useContext(ClientContext) as ClientContextType;
 
   let initialValues = {
     endpoint: data.endpoint ? data.endpoint : "http://localhost:8000/ingestion",
@@ -306,11 +323,13 @@ const SnowflakeSourceNode: FC<NodeProps> = memo(({ id, data }) => {
 
 const KafkaSourceNode: FC<NodeProps> = memo(({ id, data }) => {
   const instance = useReactFlow();
+  const { clients } = useContext(ClientContext) as ClientContextType;
 
   let initialValues = {
     brokers: data.brokers ? data.brokers : "localhost:9092",
     group_id: data.group_id ? data.group_id : "group_id",
     topics: data.topics ? data.topics : "topic-0",
+    client: data.client ? data.client : "",
   };
 
   const handleChange = useCallback((name: string, value: string) => {
@@ -330,6 +349,7 @@ const KafkaSourceNode: FC<NodeProps> = memo(({ id, data }) => {
     handleChange("brokers", initialValues.brokers);
     handleChange("group_id", initialValues.group_id);
     handleChange("topics", initialValues.topics);
+    handleChange("client", initialValues.client);
   }, [id]);
 
   return (
@@ -354,6 +374,17 @@ const KafkaSourceNode: FC<NodeProps> = memo(({ id, data }) => {
         placeholder={initialValues.topics}
         defaultValue={initialValues.topics}
         onChange={(event) => handleChange("topics", event.currentTarget.value)}
+      />
+      <Select
+        className="nodrag"
+        label="Client"
+        placeholder="Pick one"
+        defaultValue={initialValues.client}
+        searchable
+        nothingFound="No options"
+        data={(clients || []).map(c => c.id)}
+        onChange={(value) => handleChange("client", value || "")}
+        withinPortal
       />
       <Handle type="source" position={Position.Right} id={id} />
     </div>


### PR DESCRIPTION
* Clients register themselves and get a token
* Clients are shown in the UI -- right now it's just a list on the left side. I imagine that we may add more metadata about them in the future. 
* For certain types of nodes (sqlite & kafka), client is a dropdown field. Not used yet by the clients in any way.

<img width="1394" alt="Screenshot 2023-07-25 at 7 14 31 PM" src="https://github.com/mycelial/mycelial/assets/4393302/3c00e963-49d7-471f-a78a-72c6653b2181">
