### PR TITLE
Remove client auth requirement on ingestion endpoint

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -428,9 +428,9 @@ async fn main() -> anyhow::Result<()> {
     let api = Router::new()
         .route("/api/client", post(provision_client)) // no client auth needed
         .route("/api/tokens", post(issue_token)) // no client auth needed
+        .route("/ingestion", post(ingestion))
         .merge(
             Router::new()
-                .route("/ingestion", post(ingestion))
                 .route(
                     "/pipe/configs",
                     get(get_pipe_configs).post(post_pipe_config),


### PR DESCRIPTION
Basic auth is still in place, this allows client to use mycelial net with token defined in UI

In near future we might change behaviour, but for now it's OK, ingestion endpoint doesn't do anything, yet.