### PR TITLE
Update ingestion endpoint for mycelial source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1049,7 +1049,7 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 [[package]]
 name = "exp2"
 version = "0.1.0"
-source = "git+https://github.com/mycelial/pipexperiments?rev=1eaf306fb841cfbbaadee436c8e179242479797c#1eaf306fb841cfbbaadee436c8e179242479797c"
+source = "git+https://github.com/mycelial/pipexperiments?rev=9681499b0d4a50f1d9a290b0c9bf6f4755bea3ff#9681499b0d4a50f1d9a290b0c9bf6f4755bea3ff"
 dependencies = [
  "arrow",
  "base64 0.21.2",

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive", "env"] }
 reqwest = { version = "0.11", features = ["json"] }
-exp2 = { git="https://github.com/mycelial/pipexperiments", rev="1eaf306fb841cfbbaadee436c8e179242479797c" }
-# exp2 = { path = "../../pipexperiments/exp2" }
+exp2 = { git="https://github.com/mycelial/pipexperiments", rev="9681499b0d4a50f1d9a290b0c9bf6f4755bea3ff" }
+#exp2 = { path = "../../pipexperiments/exp2" }
 anyhow = "1"
 base64 = { version = "0.21" }
 serde = { version = "1", features = ["derive"]}


### PR DESCRIPTION
Endpoint now allows optional messages (i.e. no new messages available for client)
Endpoint also returns x-message-id header to provices client with id which needs to be stored on client side
