### PR TITLE
Fix quoting problem in sqlite_connector source

### DIFF
--- a/pipe/section/section_impls/sqlite_connector/src/source.rs
+++ b/pipe/section/section_impls/sqlite_connector/src/source.rs
@@ -249,7 +249,13 @@ impl Sqlite {
             let mut cols = Vec::with_capacity(columns.len());
             let mut col_types = Vec::with_capacity(columns.len());
             for column in columns {
-                cols.push(column.col_name.to_string());
+                let col_name = column
+                    .col_name
+                    .to_string()
+                    .trim_end_matches('"')
+                    .trim_start_matches('"')
+                    .to_string();
+                cols.push(col_name);
                 let ty = match column.col_type {
                     Some(ref ty) => ty,
                     None => Err("untyped column")?,


### PR DESCRIPTION
When identifying the column names in a table, the code currently parses the table_sql which has the column names quoted, so "id" is parsed in such a way that the field name is eventually "\"id\"".

This PR strips the "" from the column names in the table_sql so that by the time they are used in a schema, the field name is "id" and not "\"id\"".

There may be easier ways to achieve this.