### PR TITLE
add strict flag for excel

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -79,6 +79,7 @@ pub struct ExcelConfig {
     #[serde(flatten)]
     pub common_attrs: CommonAttrs,
     pub path: String,
+    pub strict: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]

--- a/console/components/nodes.tsx
+++ b/console/components/nodes.tsx
@@ -382,6 +382,7 @@ const ExcelSourceNode: FC<NodeProps> = memo(({ id, data, selected }) => {
       path: data.path ? data.path : "/tmp/test.xlsx",
       client: data.client ? data.client : "-",
       sheets: data.sheets ? data.sheets : "*",
+      strict: data.strict ? data.strict : "true",
     };
   }, []);
 
@@ -404,6 +405,7 @@ const ExcelSourceNode: FC<NodeProps> = memo(({ id, data, selected }) => {
     handleChange("journal_path", initialValues.path);
     handleChange("sheets", initialValues.sheets);
     handleChange("client", initialValues.client);
+    handleChange("strict", initialValues.strict);
   }, []);
 
   let classNames = `${styles.customNode} `;
@@ -464,6 +466,16 @@ const ExcelSourceNode: FC<NodeProps> = memo(({ id, data, selected }) => {
           options={(clients || []).map((c) => c.id)}
           onChange={(value) => {
             handleChange("client", value || "");
+          }}
+        />
+        <Select
+          name="strict"
+          label="Strict"
+          placeholder="Pick one"
+          defaultValue={initialValues.strict}
+          options={["true", "false"]}
+          onChange={(value) => {
+            handleChange("strict", value || "");
           }}
         />
         <Handle type="source" position={Position.Right} id={id} />

--- a/myceliald/config.example.toml
+++ b/myceliald/config.example.toml
@@ -24,6 +24,7 @@ token = "token"                    # Default token for Sqlite Physical Replicati
 type = "excel_connector"
 display_name = "Excel Source"
 path = "test.xlsx"
+strict = false
 
 # SOURCES
 # Define all data sources (data stores and directory paths)

--- a/pipe/runtime/src/sections/excel_connector/source.rs
+++ b/pipe/runtime/src/sections/excel_connector/source.rs
@@ -42,23 +42,28 @@ impl<SectionChan: SectionChannel + Send + 'static> Section<DynStream, DynSink, S
 pub fn constructor<S: SectionChannel>(
     config: &Map,
 ) -> Result<Box<dyn DynSection<S>>, SectionError> {
-    // FIXME: Use correct input config values for excel
     let sheets = config
         .get("sheets")
         .ok_or("excel section requires 'sheets'")?
         .as_str()
         .ok_or("'sheets' should be string")?;
-    let path = config
-        .get("path")
-        .ok_or("excel section requires 'path'")?
-        .as_str()
-        .ok_or("path should be string")?;
     let sheets = sheets
         .split(',')
         .map(|x| x.trim())
         .filter(|x| !x.is_empty())
         .collect::<Vec<&str>>();
+    let path = config
+        .get("path")
+        .ok_or("excel section requires 'path'")?
+        .as_str()
+        .ok_or("path should be string")?;
+    let strict: bool = config
+        .get("strict")
+        .ok_or("excel section requires 'strict'")?
+        .as_str()
+        .ok_or("strict should be string")?
+        .parse()?;
     Ok(Box::new(ExcelAdapter {
-        inner: Excel::new(path, sheets.as_slice()),
+        inner: Excel::new(path, sheets.as_slice(), strict),
     }))
 }

--- a/pipe/section/section_impls/excel_connector/src/source.rs
+++ b/pipe/section/section_impls/excel_connector/src/source.rs
@@ -28,7 +28,9 @@ impl TryFrom<(ColumnType, usize, &[DataType], bool)> for Value {
     // FIXME: specific error instead of Box<dyn Error>
     type Error = StdError;
 
-    fn try_from((col, index, row, strict): (ColumnType, usize, &[DataType], bool)) -> Result<Self, Self::Error> {
+    fn try_from(
+        (col, index, row, strict): (ColumnType, usize, &[DataType], bool),
+    ) -> Result<Self, Self::Error> {
         if !strict {
             let v2 = row.get(index).unwrap();
             let v = match v2 {
@@ -36,7 +38,11 @@ impl TryFrom<(ColumnType, usize, &[DataType], bool)> for Value {
                 DataType::Float(f) => f.to_string(),
                 DataType::String(s) => s.to_string(),
                 DataType::Bool(b) => b.to_string(),
-                DataType::DateTime(_) => v2.as_datetime().unwrap().format("%Y-%m-%d %H:%M:%S").to_string(),
+                DataType::DateTime(_) => v2
+                    .as_datetime()
+                    .unwrap()
+                    .format("%Y-%m-%d %H:%M:%S")
+                    .to_string(),
                 DataType::Duration(d) => d.to_string(),
                 DataType::DateTimeIso(d) => d.to_string(),
                 DataType::DurationIso(d) => d.to_string(),

--- a/pipe/section/section_impls/excel_connector/src/source.rs
+++ b/pipe/section/section_impls/excel_connector/src/source.rs
@@ -49,7 +49,7 @@ impl TryFrom<(ColumnType, usize, &[DataType], bool)> for Value {
                 DataType::Error(e) => e.to_string(),
                 DataType::Empty => "".to_string(),
             };
-            let v = Value::Text(v.into());
+            let v = Value::Text(v);
             return Ok(v);
         }
 


### PR DESCRIPTION
Adds a flag "strict" for the excel source section that converts everything to a string so that there's an option to get all the data in case the types don't match up perfectly. 