### PR TITLE
Add context to error message

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,7 +1,7 @@
 name: Check
 
 on:
-  push
+  [push, pull_request]
 
 jobs:
   lints:

--- a/pipe/runtime/src/pipe.rs
+++ b/pipe/runtime/src/pipe.rs
@@ -66,9 +66,9 @@ impl<R: RootChannel + Send + 'static> TryFrom<(&'_ Config, &'_ Registry<R::Secti
                         .ok_or("section needs to have a name")?
                         .as_str()
                         .ok_or("section name should be string")?;
-                    let constructor = registry
-                        .get_constructor(name)
-                        .ok_or(format!("the runtime's registry contains no constructor for '{name}' available"))?;
+                    let constructor = registry.get_constructor(name).ok_or(format!(
+                        "the runtime's registry contains no constructor for '{name}' available"
+                    ))?;
                     constructor(section_cfg)
                 },
             )

--- a/pipe/runtime/src/pipe.rs
+++ b/pipe/runtime/src/pipe.rs
@@ -68,7 +68,7 @@ impl<R: RootChannel + Send + 'static> TryFrom<(&'_ Config, &'_ Registry<R::Secti
                         .ok_or("section name should be string")?;
                     let constructor = registry
                         .get_constructor(name)
-                        .ok_or(format!("no constructor for '{name}' available"))?;
+                        .ok_or(format!("the runtime's registry contains no constructor for '{name}' available"))?;
                     constructor(section_cfg)
                 },
             )

--- a/pipe/section/section_impls/excel_connector/src/source.rs
+++ b/pipe/section/section_impls/excel_connector/src/source.rs
@@ -312,7 +312,7 @@ fn get_directory_or_filepath(path: &str) -> String {
     let split_path = path.split('/').collect::<Vec<&str>>();
     let mut directory_to_watch = String::new();
     let mut found = false;
-    for (_i, part) in split_path.iter().enumerate() {
+    for part in split_path.iter() {
         if part.contains('*') || part.contains("**") {
             found = true;
             break;


### PR DESCRIPTION
The registry used here only comes from the runtime. If there is a typo in the registry or the requested section the error message should help you figure out that where the problem possibly is.
