### PR TITLE
Add context to error message

### DIFF
--- a/pipe/runtime/src/pipe.rs
+++ b/pipe/runtime/src/pipe.rs
@@ -66,9 +66,9 @@ impl<R: RootChannel + Send + 'static> TryFrom<(&'_ Config, &'_ Registry<R::Secti
                         .ok_or("section needs to have a name")?
                         .as_str()
                         .ok_or("section name should be string")?;
-                    let constructor = registry
-                        .get_constructor(name)
-                        .ok_or(format!("no constructor for '{name}' available"))?;
+                    let constructor = registry.get_constructor(name).ok_or(format!(
+                        "the runtime's registry contains no constructor for '{name}' available"
+                    ))?;
                     constructor(section_cfg)
                 },
             )


### PR DESCRIPTION
This registry only comes from the runtime, if there is a typo in the registry or the requested section the error message should help you figure out that where the problem possibly is.