### PR TITLE
run check workflow on pull_requests as well

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,7 +1,7 @@
 name: Check
 
 on:
-  push
+  [push, pull_request]
 
 jobs:
   lints:


### PR DESCRIPTION
When I was testing my permission to push to the repo @alexandrinaw noticed that the check workflow doesn't run on PR's from outside contributors. This adds the PR trigger to that workflow.