### PR TITLE
WIP: tagging transformer passes ack forward and backward

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3911,6 +3911,7 @@ dependencies = [
 name = "tagging_transformer"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "arrow 49.0.0",
  "arrow_msg",
  "futures",

--- a/pipe/section/section_impls/tagging_transformer/Cargo.toml
+++ b/pipe/section/section_impls/tagging_transformer/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-section = { path = "../../" }
+anyhow = "1.0"
 arrow = { version = "49", features = ["prettyprint"] }
 arrow_msg = { path = "../../../arrow_msg" }
 futures = "0.3"
+section = { path = "../../" }

--- a/pipe/section/section_impls/tagging_transformer/src/lib.rs
+++ b/pipe/section/section_impls/tagging_transformer/src/lib.rs
@@ -1,6 +1,8 @@
 use std::pin::pin;
 use std::sync::Arc;
 
+use anyhow::{anyhow, Result};
+
 use arrow::array::StringArray;
 use arrow::datatypes::DataType as ArrowDataType;
 use arrow::datatypes::Field;
@@ -10,10 +12,11 @@ use arrow::record_batch::RecordBatch as ArrowRecordBatch;
 use arrow_msg::df_to_recordbatch;
 use arrow_msg::ArrowMsg;
 
-use section::command_channel::{Command, SectionChannel};
+use section::command_channel::{Command, SectionChannel, WeakSectionChannel};
 use section::futures::{self, Sink, SinkExt, Stream};
 use section::futures::{FutureExt, StreamExt};
-use section::pretty_print::pretty_print;
+use section::message::Ack;
+use section::message::DataFrame;
 use section::section::Section;
 use section::{message::Chunk, SectionError, SectionFuture, SectionMessage};
 
@@ -36,6 +39,40 @@ impl TaggingTransformer {
             text: text.to_string(),
         }
     }
+
+    /// Handles an incoming DataFrame message by adding a column with the configured text
+    async fn handle_message(&self, df: Box<dyn DataFrame>, ack: Ack) -> Result<ArrowMsg> {
+        // Convert to a RecordBatch from the arrow crate
+        let rb = match df_to_recordbatch(df) {
+            Ok(rb) => rb,
+            Err(_) => return Err(anyhow!("couldn't parse DataFrame into RecordBatch")),
+        };
+        let old_schema = rb.schema();
+        let old_cols = rb.columns();
+
+        // Create a new schema from the old schema and push on a new field
+        let mut builder = SchemaBuilder::from(old_schema.fields());
+        builder.push(Field::new(self.column.clone(), ArrowDataType::Utf8, false));
+        let new_schema = builder.finish();
+
+        // Push a new value onto the old columns
+        let mut values = old_cols
+            .iter()
+            .map(std::borrow::ToOwned::to_owned)
+            .collect::<Vec<_>>();
+        let tag = Arc::new(StringArray::from(vec![self.text.clone()]));
+        values.push(tag);
+
+        // create a new arrow RecordBatch from the schema and columns
+        let new_rb = ArrowRecordBatch::try_new(Arc::new(new_schema), values)?;
+
+        // create a message from the RecordBatch
+        Ok(ArrowMsg::new(
+            "tagging transformer",
+            vec![Some(new_rb.into())],
+            Some(ack),
+        ))
+    }
 }
 
 impl<Input, Output, SectionChan> Section<Input, Output, SectionChan> for TaggingTransformer
@@ -55,8 +92,14 @@ where
             loop {
                 futures::select! {
                     cmd = section_channel.recv().fuse() => {
-                        if let Command::Stop = cmd? {
-                            return Ok(())
+                        match cmd? {
+                            Command::Ack(ack_msg) => {
+                                let weak_chan = section_channel.weak_chan();
+                                weak_chan.ack(Box::new(ack_msg)).await;
+
+                            },
+                            Command::Stop => return Ok(()),
+                            _ => {},
                         }
                     }
                     stream = input.next() => {
@@ -69,40 +112,9 @@ where
                                 msg = stream.next().fuse() => {
                                     match msg? {
                                         Some(Chunk::DataFrame(df)) => {
-                                            section_channel.log(format!("transform got dataframe chunk from {}:\n{}",
-                                                stream.origin(),
-                                                pretty_print(&*df))).await?;
-
-                                            // Convert to a RecordBatch from the arrow crate
-                                            let rb = df_to_recordbatch(df)?;
-                                            let old_schema = rb.schema();
-                                            let old_cols = rb.columns();
-
-                                            // Create a new schema from the old schema and push on a new field
-                                            let mut builder = SchemaBuilder::from(old_schema.fields());
-                                            builder.push(Field::new(self.column.clone(), ArrowDataType::Utf8, false));
-                                            let new_schema = builder.finish();
-
-                                            // Push a new value onto the old columns
-                                            let mut values = old_cols
-                                                .iter()
-                                                .map(std::borrow::ToOwned::to_owned)
-                                                .collect::<Vec<_>>();
-                                            let tag = Arc::new(StringArray::from(vec![self.text.clone()]));
-                                            values.push(tag);
-
-                                            // create a new arrow RecordBatch from the schema and columns
-                                            let new_rb = ArrowRecordBatch::try_new(
-                                                Arc::new(new_schema),
-                                                values,
-                                            )?;
-
-                                            // create a message from the RecordBatch
-                                            let new_msg = ArrowMsg::new("tagging transformer", vec![Some(new_rb.into())], None);
-
+                                            let new_msg = self.handle_message(df, stream.ack()).await?;
                                             output.send(Box::new(new_msg)).await.ok();
                                             section_channel.log("payload sent").await?;
-
                                         },
                                         Some(_) => {Err("unsupported stream type, dataframe expected")?},
                                         None => break,


### PR DESCRIPTION
Working on getting the tagging transformer to pass the ack message forwards and backwards. This also refactors out the bulk of the message building because being nested under several 'loop' and 'select' statements seem to make rust-analyzer unhappy(but that's a problem for another day).