### PR TITLE
Union array iterator refactoring

### DIFF
--- a/pipe/arrow_msg/src/lib.rs
+++ b/pipe/arrow_msg/src/lib.rs
@@ -117,14 +117,30 @@ fn union_array_to_iter<'a>(
         let field = field_map.get(&type_id).unwrap();
         match field.data_type() {
             ArrowDataType::Null => ValueView::Null,
-            ArrowDataType::Int8 => ValueView::I8(child.as_primitive::<Int8Type>().value(value_offset)),
-            ArrowDataType::Int16 => ValueView::I16(child.as_primitive::<Int16Type>().value(value_offset)),
-            ArrowDataType::Int32 => ValueView::I32(child.as_primitive::<Int32Type>().value(value_offset)),
-            ArrowDataType::Int64 => ValueView::I64(child.as_primitive::<Int64Type>().value(value_offset)),
-            ArrowDataType::UInt8 => ValueView::U8(child.as_primitive::<UInt8Type>().value(value_offset)),
-            ArrowDataType::UInt16 => ValueView::U16(child.as_primitive::<UInt16Type>().value(value_offset)),
-            ArrowDataType::UInt32 => ValueView::U32(child.as_primitive::<UInt32Type>().value(value_offset)),
-            ArrowDataType::UInt64 => ValueView::U64(child.as_primitive::<UInt64Type>().value(value_offset)),
+            ArrowDataType::Int8 => {
+                ValueView::I8(child.as_primitive::<Int8Type>().value(value_offset))
+            }
+            ArrowDataType::Int16 => {
+                ValueView::I16(child.as_primitive::<Int16Type>().value(value_offset))
+            }
+            ArrowDataType::Int32 => {
+                ValueView::I32(child.as_primitive::<Int32Type>().value(value_offset))
+            }
+            ArrowDataType::Int64 => {
+                ValueView::I64(child.as_primitive::<Int64Type>().value(value_offset))
+            }
+            ArrowDataType::UInt8 => {
+                ValueView::U8(child.as_primitive::<UInt8Type>().value(value_offset))
+            }
+            ArrowDataType::UInt16 => {
+                ValueView::U16(child.as_primitive::<UInt16Type>().value(value_offset))
+            }
+            ArrowDataType::UInt32 => {
+                ValueView::U32(child.as_primitive::<UInt32Type>().value(value_offset))
+            }
+            ArrowDataType::UInt64 => {
+                ValueView::U64(child.as_primitive::<UInt64Type>().value(value_offset))
+            }
             ArrowDataType::Float32 => {
                 ValueView::F32(child.as_primitive::<Float32Type>().value(value_offset))
             }
@@ -132,57 +148,53 @@ fn union_array_to_iter<'a>(
                 ValueView::F64(child.as_primitive::<Float64Type>().value(value_offset))
             }
             ArrowDataType::Utf8 => ValueView::Str(child.as_string::<i32>().value(value_offset)),
-            ArrowDataType::LargeUtf8 => ValueView::Str(child.as_string::<i32>().value(value_offset)),
+            ArrowDataType::LargeUtf8 => {
+                ValueView::Str(child.as_string::<i32>().value(value_offset))
+            }
             ArrowDataType::Binary => ValueView::Bin(child.as_binary::<i32>().value(value_offset)),
-            ArrowDataType::LargeBinary => ValueView::Bin(child.as_binary::<i32>().value(value_offset)),
+            ArrowDataType::LargeBinary => {
+                ValueView::Bin(child.as_binary::<i32>().value(value_offset))
+            }
             ArrowDataType::Decimal128(scale, _precision) => ValueView::Decimal({
                 let d = child.as_primitive::<Decimal128Type>().value(value_offset);
                 Decimal::from_i128_with_scale(d, *scale as _)
             }),
-            ArrowDataType::Time32(tu) => {
-                match tu {
-                    ArrowTimeUnit::Second => ValueView::Time(
-                        TimeUnit::Second,
-                        child.as_primitive::<Time32SecondType>().value(value_offset) as _,
-                    ),
-                    ArrowTimeUnit::Millisecond => ValueView::Time(
-                        TimeUnit::Millisecond,
-                        child
-                            .as_primitive::<Time32MillisecondType>()
-                            .value(value_offset) as _,
-                    ),
-                    _ => unreachable!("time32 encodes only seconds or milliseconds")
-                }
-            },
-            ArrowDataType::Time64(tu) => {
-                match tu {
-                    ArrowTimeUnit::Microsecond => ValueView::Time(
-                        TimeUnit::Microsecond,
-                        child
-                            .as_primitive::<Time64MicrosecondType>()
-                            .value(value_offset),
-                    ),
-                    ArrowTimeUnit::Nanosecond => ValueView::Time(
-                        TimeUnit::Nanosecond,
-                        child
-                            .as_primitive::<Time64NanosecondType>()
-                            .value(value_offset),
-                    ),
-                    _ => unreachable!("time64 encodes only microseconds or nanoseconds")
-                }
-            },
-            ArrowDataType::Date32 => {
-                ValueView::Date(
+            ArrowDataType::Time32(tu) => match tu {
+                ArrowTimeUnit::Second => ValueView::Time(
                     TimeUnit::Second,
-                    child.as_primitive::<Date32Type>().value(value_offset) as i64 * 86400
-                )
-            },
-            ArrowDataType::Date64 => {
-                ValueView::Date(
+                    child.as_primitive::<Time32SecondType>().value(value_offset) as _,
+                ),
+                ArrowTimeUnit::Millisecond => ValueView::Time(
                     TimeUnit::Millisecond,
-                    child.as_primitive::<Date64Type>().value(value_offset),
-                )
+                    child
+                        .as_primitive::<Time32MillisecondType>()
+                        .value(value_offset) as _,
+                ),
+                _ => unreachable!("time32 encodes only seconds or milliseconds"),
             },
+            ArrowDataType::Time64(tu) => match tu {
+                ArrowTimeUnit::Microsecond => ValueView::Time(
+                    TimeUnit::Microsecond,
+                    child
+                        .as_primitive::<Time64MicrosecondType>()
+                        .value(value_offset),
+                ),
+                ArrowTimeUnit::Nanosecond => ValueView::Time(
+                    TimeUnit::Nanosecond,
+                    child
+                        .as_primitive::<Time64NanosecondType>()
+                        .value(value_offset),
+                ),
+                _ => unreachable!("time64 encodes only microseconds or nanoseconds"),
+            },
+            ArrowDataType::Date32 => ValueView::Date(
+                TimeUnit::Second,
+                child.as_primitive::<Date32Type>().value(value_offset) as i64 * 86400,
+            ),
+            ArrowDataType::Date64 => ValueView::Date(
+                TimeUnit::Millisecond,
+                child.as_primitive::<Date64Type>().value(value_offset),
+            ),
             ArrowDataType::Timestamp(tu, tz) => {
                 let value = match tu {
                     ArrowTimeUnit::Second => child

--- a/pipe/arrow_msg/src/lib.rs
+++ b/pipe/arrow_msg/src/lib.rs
@@ -109,102 +109,107 @@ fn union_array_to_iter<'a>(
     union_fields: &'a UnionFields,
     array: &'a UnionArray,
 ) -> Box<dyn Iterator<Item = ValueView<'a>> + Send + 'a> {
-    let iter = (0..array.len()).map(|index| {
-        let field_map: HashMap<i8, &Arc<Field>> = union_fields.iter().collect();
+    let field_map: HashMap<i8, &Arc<Field>> = union_fields.iter().collect();
+    let iter = (0..array.len()).map(move |index| {
         let type_id = array.type_id(index);
         let value_offset = array.value_offset(index);
         let child = array.child(type_id);
-        match DataType::from(type_id) {
-            DataType::Null => ValueView::Null,
-            DataType::I8 => ValueView::I8(child.as_primitive::<Int8Type>().value(value_offset)),
-            DataType::I16 => ValueView::I16(child.as_primitive::<Int16Type>().value(value_offset)),
-            DataType::I32 => ValueView::I32(child.as_primitive::<Int32Type>().value(value_offset)),
-            DataType::I64 => ValueView::I64(child.as_primitive::<Int64Type>().value(value_offset)),
-            DataType::U8 => ValueView::U8(child.as_primitive::<UInt8Type>().value(value_offset)),
-            DataType::U16 => ValueView::U16(child.as_primitive::<UInt16Type>().value(value_offset)),
-            DataType::U32 => ValueView::U32(child.as_primitive::<UInt32Type>().value(value_offset)),
-            DataType::U64 => ValueView::U64(child.as_primitive::<UInt64Type>().value(value_offset)),
-            DataType::F32 => {
+        let field = field_map.get(&type_id).unwrap();
+        match field.data_type() {
+            ArrowDataType::Null => ValueView::Null,
+            ArrowDataType::Int8 => ValueView::I8(child.as_primitive::<Int8Type>().value(value_offset)),
+            ArrowDataType::Int16 => ValueView::I16(child.as_primitive::<Int16Type>().value(value_offset)),
+            ArrowDataType::Int32 => ValueView::I32(child.as_primitive::<Int32Type>().value(value_offset)),
+            ArrowDataType::Int64 => ValueView::I64(child.as_primitive::<Int64Type>().value(value_offset)),
+            ArrowDataType::UInt8 => ValueView::U8(child.as_primitive::<UInt8Type>().value(value_offset)),
+            ArrowDataType::UInt16 => ValueView::U16(child.as_primitive::<UInt16Type>().value(value_offset)),
+            ArrowDataType::UInt32 => ValueView::U32(child.as_primitive::<UInt32Type>().value(value_offset)),
+            ArrowDataType::UInt64 => ValueView::U64(child.as_primitive::<UInt64Type>().value(value_offset)),
+            ArrowDataType::Float32 => {
                 ValueView::F32(child.as_primitive::<Float32Type>().value(value_offset))
             }
-            DataType::F64 => {
+            ArrowDataType::Float64 => {
                 ValueView::F64(child.as_primitive::<Float64Type>().value(value_offset))
             }
-            DataType::Str => ValueView::Str(child.as_string::<i32>().value(value_offset)),
-            DataType::Bin => ValueView::Bin(child.as_binary::<i32>().value(value_offset)),
-            DataType::Decimal => ValueView::Decimal({
+            ArrowDataType::Utf8 => ValueView::Str(child.as_string::<i32>().value(value_offset)),
+            ArrowDataType::LargeUtf8 => ValueView::Str(child.as_string::<i32>().value(value_offset)),
+            ArrowDataType::Binary => ValueView::Bin(child.as_binary::<i32>().value(value_offset)),
+            ArrowDataType::LargeBinary => ValueView::Bin(child.as_binary::<i32>().value(value_offset)),
+            ArrowDataType::Decimal128(scale, _precision) => ValueView::Decimal({
                 let d = child.as_primitive::<Decimal128Type>().value(value_offset);
-                let field = *field_map.get(&type_id).unwrap();
-                if let ArrowDataType::Decimal128(_, scale) = field.data_type() {
-                    Decimal::from_i128_with_scale(d, *scale as _)
-                } else {
-                    panic!(
-                        "expected field data type to be Decimal128, got {:?} instead",
-                        field
-                    )
-                }
+                Decimal::from_i128_with_scale(d, *scale as _)
             }),
-            DataType::Time(tu) => match tu {
-                TimeUnit::Second => ValueView::Time(
-                    tu,
-                    child.as_primitive::<Time32SecondType>().value(value_offset) as _,
-                ),
-                TimeUnit::Millisecond => ValueView::Time(
-                    tu,
-                    child
-                        .as_primitive::<Time32MillisecondType>()
-                        .value(value_offset) as _,
-                ),
-                TimeUnit::Microsecond => ValueView::Time(
-                    tu,
-                    child
-                        .as_primitive::<Time64MicrosecondType>()
-                        .value(value_offset),
-                ),
-                TimeUnit::Nanosecond => ValueView::Time(
-                    tu,
-                    child
-                        .as_primitive::<Time64NanosecondType>()
-                        .value(value_offset),
-                ),
+            ArrowDataType::Time32(tu) => {
+                match tu {
+                    ArrowTimeUnit::Second => ValueView::Time(
+                        TimeUnit::Second,
+                        child.as_primitive::<Time32SecondType>().value(value_offset) as _,
+                    ),
+                    ArrowTimeUnit::Millisecond => ValueView::Time(
+                        TimeUnit::Millisecond,
+                        child
+                            .as_primitive::<Time32MillisecondType>()
+                            .value(value_offset) as _,
+                    ),
+                    _ => unreachable!("time32 encodes only seconds or milliseconds")
+                }
             },
-            DataType::Date(_tu) => ValueView::Time(
-                TimeUnit::Millisecond,
-                child.as_primitive::<Date64Type>().value(value_offset),
-            ),
-            DataType::TimeStamp(tu) => {
+            ArrowDataType::Time64(tu) => {
+                match tu {
+                    ArrowTimeUnit::Microsecond => ValueView::Time(
+                        TimeUnit::Microsecond,
+                        child
+                            .as_primitive::<Time64MicrosecondType>()
+                            .value(value_offset),
+                    ),
+                    ArrowTimeUnit::Nanosecond => ValueView::Time(
+                        TimeUnit::Nanosecond,
+                        child
+                            .as_primitive::<Time64NanosecondType>()
+                            .value(value_offset),
+                    ),
+                    _ => unreachable!("time64 encodes only microseconds or nanoseconds")
+                }
+            },
+            ArrowDataType::Date32 => {
+                ValueView::Date(
+                    TimeUnit::Second,
+                    child.as_primitive::<Date32Type>().value(value_offset) as i64 * 86400
+                )
+            },
+            ArrowDataType::Date64 => {
+                ValueView::Date(
+                    TimeUnit::Millisecond,
+                    child.as_primitive::<Date64Type>().value(value_offset),
+                )
+            },
+            ArrowDataType::Timestamp(tu, tz) => {
                 let value = match tu {
-                    TimeUnit::Second => child
+                    ArrowTimeUnit::Second => child
                         .as_primitive::<TimestampSecondType>()
                         .value(value_offset),
-                    TimeUnit::Millisecond => child
+                    ArrowTimeUnit::Millisecond => child
                         .as_primitive::<TimestampMillisecondType>()
                         .value(value_offset),
-                    TimeUnit::Microsecond => child
+                    ArrowTimeUnit::Microsecond => child
                         .as_primitive::<TimestampMicrosecondType>()
                         .value(value_offset),
-                    TimeUnit::Nanosecond => child
+                    ArrowTimeUnit::Nanosecond => child
                         .as_primitive::<TimestampNanosecondType>()
                         .value(value_offset),
                 };
-                ValueView::TimeStamp(tu, value)
-            }
-            DataType::TimeStampUTC(tu) => {
-                let value = match tu {
-                    TimeUnit::Second => child
-                        .as_primitive::<TimestampSecondType>()
-                        .value(value_offset),
-                    TimeUnit::Millisecond => child
-                        .as_primitive::<TimestampMillisecondType>()
-                        .value(value_offset),
-                    TimeUnit::Microsecond => child
-                        .as_primitive::<TimestampMicrosecondType>()
-                        .value(value_offset),
-                    TimeUnit::Nanosecond => child
-                        .as_primitive::<TimestampNanosecondType>()
-                        .value(value_offset),
-                };
-                ValueView::TimeStampUTC(tu, value)
+                let tu = from_arrow_timeunit(tu);
+                match tz {
+                    None => ValueView::TimeStamp(tu, value),
+                    Some(tz) => {
+                        let offset: i64 = tz
+                            .as_ref()
+                            .parse::<FixedOffset>()
+                            .unwrap()
+                            .utc_minus_local() as i64;
+                        ValueView::TimeStampUTC(tu, value + offset)
+                    }
+                }
             }
             dt => unimplemented!("unimplemented dt: {}", dt),
         }
@@ -376,7 +381,7 @@ impl DataFrame for RecordBatch {
                         _ => unimplemented!("Time32 only supports time unit in seconds"),
                     },
                     ArrowDataType::Time64(tu) => {
-                        let tu = from_arrow_timeunit(tu.clone());
+                        let tu = from_arrow_timeunit(tu);
                         let iter: Box<dyn Iterator<Item = ValueView> + Send> = match tu {
                             TimeUnit::Microsecond => {
                                 let arr = column.as_primitive::<Time64MicrosecondType>();
@@ -570,7 +575,7 @@ fn into_arrow_timeunit(tu: TimeUnit) -> ArrowTimeUnit {
     }
 }
 
-fn from_arrow_timeunit(tu: ArrowTimeUnit) -> TimeUnit {
+fn from_arrow_timeunit(tu: &ArrowTimeUnit) -> TimeUnit {
     match tu {
         ArrowTimeUnit::Second => TimeUnit::Second,
         ArrowTimeUnit::Millisecond => TimeUnit::Millisecond,

--- a/pipe/arrow_msg/tests/union_array_iter.rs
+++ b/pipe/arrow_msg/tests/union_array_iter.rs
@@ -1,12 +1,18 @@
 use arrow::{
-    array::{Array, Float64Array, Int32Array, StringArray, UnionArray, Int8Array, Int16Array, Int64Array, Float32Array, BinaryArray, Time32SecondArray, Time32MillisecondArray, Time64MicrosecondArray, Time64NanosecondArray, Date32Array, Date64Array, UInt8Array, UInt16Array, UInt32Array, UInt64Array, ArrayRef, Decimal128Array, TimestampSecondArray, TimestampMillisecondArray, TimestampMicrosecondArray, TimestampNanosecondArray},
+    array::{
+        Array, ArrayRef, BinaryArray, Date32Array, Date64Array, Float32Array,
+        Float64Array, Int16Array, Int32Array, Int64Array, Int8Array, StringArray,
+        Time32MillisecondArray, Time32SecondArray, Time64MicrosecondArray, Time64NanosecondArray,
+        TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
+        TimestampSecondArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array, UnionArray,
+    },
     buffer::Buffer,
     datatypes::{DataType as ArrowDataType, Field, Schema, UnionFields, UnionMode},
     record_batch::RecordBatch as ArrowRecordBatch,
 };
 use arrow_msg::RecordBatch;
 use quickcheck::TestResult;
-use section::message::{DataFrame, ValueView, TimeUnit};
+use section::message::{DataFrame, TimeUnit, ValueView};
 use std::{collections::HashSet, sync::Arc};
 
 pub struct XorShift64 {
@@ -38,31 +44,24 @@ fn test_union_array_iter() {
             Arc::new(Int16Array::from(vec![-16])),
             Arc::new(Int32Array::from(vec![-32])),
             Arc::new(Int64Array::from(vec![-64])),
-
             Arc::new(UInt8Array::from(vec![8])),
             Arc::new(UInt16Array::from(vec![16])),
             Arc::new(UInt32Array::from(vec![32])),
             Arc::new(UInt64Array::from(vec![64])),
-
             Arc::new(Float32Array::from(vec![3.2])),
             Arc::new(Float64Array::from(vec![6.4])),
-
             Arc::new(Time32SecondArray::from(vec![100])),
             Arc::new(Time32MillisecondArray::from(vec![200])),
             Arc::new(Time64MicrosecondArray::from(vec![300])),
             Arc::new(Time64NanosecondArray::from(vec![400])),
-
             Arc::new(Date32Array::from(vec![1])),
             Arc::new(Date64Array::from(vec![2])),
-
             Arc::new(TimestampSecondArray::from(vec![1])),
             Arc::new(TimestampMillisecondArray::from(vec![2])),
             Arc::new(TimestampMicrosecondArray::from(vec![3])),
             Arc::new(TimestampNanosecondArray::from(vec![4])),
-
             Arc::new(StringArray::from(vec!["one"])),
             Arc::new(BinaryArray::from(vec![b"bin".as_slice()])),
-
             // FIXME: add decimals
         ];
 
@@ -76,11 +75,13 @@ fn test_union_array_iter() {
         let type_id_buffer = Buffer::from_slice_ref(type_ids.as_slice());
         let value_offsets_buffer = Buffer::from_iter((0..type_ids.len()).map(|_| 0));
 
-        let children: Vec<(Field, Arc<dyn Array>)> = arrays.into_iter().map(|array| {
-            let dt = array.data_type();
-            let field = Field::new(format!("{:?}", dt), dt.clone(), true);
-            (field, array)
-        })
+        let children: Vec<(Field, Arc<dyn Array>)> = arrays
+            .into_iter()
+            .map(|array| {
+                let dt = array.data_type();
+                let field = Field::new(format!("{:?}", dt), dt.clone(), true);
+                (field, array)
+            })
             .collect();
 
         let fields: Vec<_> = children.iter().map(|(f, _)| f.clone()).collect();
@@ -112,28 +113,22 @@ fn test_union_array_iter() {
                 ValueView::I16(-16),
                 ValueView::I32(-32),
                 ValueView::I64(-64),
-
                 ValueView::U8(8),
                 ValueView::U16(16),
                 ValueView::U32(32),
                 ValueView::U64(64),
-
                 ValueView::F32(3.2),
                 ValueView::F64(6.4),
-
                 ValueView::Time(TimeUnit::Second, 100),
                 ValueView::Time(TimeUnit::Millisecond, 200),
                 ValueView::Time(TimeUnit::Microsecond, 300),
                 ValueView::Time(TimeUnit::Nanosecond, 400),
-
                 ValueView::Date(TimeUnit::Second, 86400),
                 ValueView::Date(TimeUnit::Millisecond, 2),
-
                 ValueView::TimeStamp(TimeUnit::Second, 1),
                 ValueView::TimeStamp(TimeUnit::Millisecond, 2),
                 ValueView::TimeStamp(TimeUnit::Microsecond, 3),
                 ValueView::TimeStamp(TimeUnit::Nanosecond, 4),
-
                 ValueView::Str("one"),
                 ValueView::Bin(b"bin".as_slice())
             ],

--- a/pipe/arrow_msg/tests/union_array_iter.rs
+++ b/pipe/arrow_msg/tests/union_array_iter.rs
@@ -1,8 +1,8 @@
 use arrow::{
     array::{
-        Array, ArrayRef, BinaryArray, Date32Array, Date64Array, Float32Array,
-        Float64Array, Int16Array, Int32Array, Int64Array, Int8Array, StringArray,
-        Time32MillisecondArray, Time32SecondArray, Time64MicrosecondArray, Time64NanosecondArray,
+        Array, ArrayRef, BinaryArray, Date32Array, Date64Array, Float32Array, Float64Array,
+        Int16Array, Int32Array, Int64Array, Int8Array, StringArray, Time32MillisecondArray,
+        Time32SecondArray, Time64MicrosecondArray, Time64NanosecondArray,
         TimestampMicrosecondArray, TimestampMillisecondArray, TimestampNanosecondArray,
         TimestampSecondArray, UInt16Array, UInt32Array, UInt64Array, UInt8Array, UnionArray,
     },

--- a/pipe/arrow_msg/tests/union_array_iter.rs
+++ b/pipe/arrow_msg/tests/union_array_iter.rs
@@ -1,0 +1,98 @@
+use arrow::{
+    array::{Array, Float64Array, Int32Array, StringArray, UnionArray},
+    buffer::Buffer,
+    datatypes::{DataType as ArrowDataType, Field, UnionMode, UnionFields, Schema},
+    record_batch::RecordBatch as ArrowRecordBatch,
+};
+use arrow_msg::RecordBatch;
+use quickcheck::TestResult;
+use section::message::{DataFrame, ValueView};
+use std::{collections::HashSet, sync::Arc};
+
+pub struct XorShift64 {
+    state: u64,
+}
+
+impl XorShift64 {
+    fn new(state: u64) -> Self {
+        Self {
+            state: state.max(1),
+        }
+    }
+    fn next(&mut self) -> u64 {
+        self.state ^= self.state << 13;
+        self.state ^= self.state >> 7;
+        self.state ^= self.state << 17;
+        self.state
+    }
+}
+
+// Goal of this test is to check that union array type_id is insignificant.
+// In order to do so we will create union array with randomly assigned type_id
+// Derived dataframe should output exactly same values of any set of type_ids
+#[test]
+fn test_union_array_iter() {
+    fn check(seed: u64) -> TestResult {
+        let mut hashset = HashSet::new();
+        let mut prng = XorShift64::new(seed);
+        while hashset.len() < 3 {
+            hashset.insert(((prng.next() % 127) as i8).abs());
+        }
+        let type_ids: Vec<i8> = hashset.iter().copied().collect();
+        let int_array = Int32Array::from(vec![1, 34]);
+        let float_array = Float64Array::from(vec![3.2]);
+        let string_array = StringArray::from(vec!["one", "two"]);
+        let type_id_buffer = Buffer::from_slice_ref(&[
+            type_ids[0],
+            type_ids[1],
+            type_ids[0],
+            type_ids[2],
+            type_ids[2],
+        ]);
+        let value_offsets_buffer = Buffer::from_slice_ref(&[0_i32, 0, 1, 0, 1]);
+
+        let children: Vec<(Field, Arc<dyn Array>)> = vec![
+            (
+                Field::new("i32", ArrowDataType::Int32, true),
+                Arc::new(int_array),
+            ),
+            (
+                Field::new("f64", ArrowDataType::Float64, true),
+                Arc::new(float_array),
+            ),
+            (
+                Field::new("str", ArrowDataType::Utf8, true),
+                Arc::new(string_array),
+            ),
+        ];
+
+        let fields: Vec<_> = children.iter().map(|(f, _)| f.clone()).collect();
+
+        let array = UnionArray::try_new(
+            &type_ids,
+            type_id_buffer,
+            Some(value_offsets_buffer),
+            children,
+        )
+            .unwrap();
+        let union_dt = ArrowDataType::Union(UnionFields::new(type_ids, fields), UnionMode::Dense);
+        let record_batch = ArrowRecordBatch::try_new(
+            Arc::new(Schema::new(vec![Field::new("union_test", union_dt, true)])),
+            vec![Arc::new(array)],
+        )
+            .unwrap();
+
+        let df: Box<dyn DataFrame> = Box::new(RecordBatch::new(record_batch));
+        let mut columns = df.columns();
+        assert_eq!(columns.len(), 1);
+        let column = columns.pop().unwrap();
+        assert_eq!(column.name(), "union_test");
+
+        assert_eq!(
+            column.collect::<Vec<ValueView>>(),
+            vec![ValueView::I32(1), ValueView::F64(3.2), ValueView::I32(34), ValueView::Str("one"), ValueView::Str("two")],
+        );
+        TestResult::passed()
+    }
+    quickcheck::quickcheck(check as fn(u64) -> TestResult);
+}

--- a/pipe/arrow_msg/tests/union_array_iter.rs
+++ b/pipe/arrow_msg/tests/union_array_iter.rs
@@ -1,7 +1,7 @@
 use arrow::{
     array::{Array, Float64Array, Int32Array, StringArray, UnionArray},
     buffer::Buffer,
-    datatypes::{DataType as ArrowDataType, Field, UnionMode, UnionFields, Schema},
+    datatypes::{DataType as ArrowDataType, Field, Schema, UnionFields, UnionMode},
     record_batch::RecordBatch as ArrowRecordBatch,
 };
 use arrow_msg::RecordBatch;
@@ -42,14 +42,14 @@ fn test_union_array_iter() {
         let int_array = Int32Array::from(vec![1, 34]);
         let float_array = Float64Array::from(vec![3.2]);
         let string_array = StringArray::from(vec!["one", "two"]);
-        let type_id_buffer = Buffer::from_slice_ref(&[
+        let type_id_buffer = Buffer::from_slice_ref([
             type_ids[0],
             type_ids[1],
             type_ids[0],
             type_ids[2],
             type_ids[2],
         ]);
-        let value_offsets_buffer = Buffer::from_slice_ref(&[0_i32, 0, 1, 0, 1]);
+        let value_offsets_buffer = Buffer::from_slice_ref([0_i32, 0, 1, 0, 1]);
 
         let children: Vec<(Field, Arc<dyn Array>)> = vec![
             (
@@ -74,13 +74,13 @@ fn test_union_array_iter() {
             Some(value_offsets_buffer),
             children,
         )
-            .unwrap();
+        .unwrap();
         let union_dt = ArrowDataType::Union(UnionFields::new(type_ids, fields), UnionMode::Dense);
         let record_batch = ArrowRecordBatch::try_new(
             Arc::new(Schema::new(vec![Field::new("union_test", union_dt, true)])),
             vec![Arc::new(array)],
         )
-            .unwrap();
+        .unwrap();
 
         let df: Box<dyn DataFrame> = Box::new(RecordBatch::new(record_batch));
         let mut columns = df.columns();
@@ -90,7 +90,13 @@ fn test_union_array_iter() {
 
         assert_eq!(
             column.collect::<Vec<ValueView>>(),
-            vec![ValueView::I32(1), ValueView::F64(3.2), ValueView::I32(34), ValueView::Str("one"), ValueView::Str("two")],
+            vec![
+                ValueView::I32(1),
+                ValueView::F64(3.2),
+                ValueView::I32(34),
+                ValueView::Str("one"),
+                ValueView::Str("two")
+            ],
         );
         TestResult::passed()
     }


### PR DESCRIPTION
Previously iteration over union array was tied to mapping of section DataType to i8.
This PR removes that bound and uses type, which is specified in arrow schema.