### PR TITLE
Add binary stream support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3398,6 +3398,7 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "arrow 42.0.0",
+ "async-stream",
  "axum",
  "base64 0.21.5",
  "chrono",

--- a/pipe/section/section_impls/mycelial_server/src/destination.rs
+++ b/pipe/section/section_impls/mycelial_server/src/destination.rs
@@ -44,7 +44,9 @@ impl<T: Stream> Stream for S<T> {
     }
 }
 
-async fn to_stream(mut msg: Box<dyn Message>) -> (StreamType, impl Stream<Item = Result<Chunk, SectionError>>) {
+async fn to_stream(
+    mut msg: Box<dyn Message>,
+) -> (StreamType, impl Stream<Item = Result<Chunk, SectionError>>) {
     let chunk = msg.next().await;
     let stream_type = match chunk {
         Ok(Some(Chunk::DataFrame(_))) => StreamType::DataFrame,

--- a/pipe/section/section_impls/mycelial_server/src/destination.rs
+++ b/pipe/section/section_impls/mycelial_server/src/destination.rs
@@ -13,18 +13,68 @@ use section::{
     section::Section,
     SectionError, SectionFuture, SectionMessage,
 };
+use std::fmt::Display;
 use std::{
     pin::{pin, Pin},
     task::{Context, Poll},
 };
-
-use crate::StreamType;
 
 #[derive(Debug)]
 pub struct Mycelial {
     endpoint: String,
     token: String,
     topic: String,
+}
+
+// should we just introduce additional method in message trait to indicate stream type?
+#[derive(Debug)]
+pub(crate) enum StreamType<T> {
+    DataFrame(T),
+    BinStream(T),
+}
+
+impl<T> StreamType<T> {
+    fn into_inner(self) -> T {
+        match self {
+            Self::DataFrame(s) => s,
+            Self::BinStream(s) => s,
+        }
+    }
+}
+
+impl<T> Display for StreamType<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let desc = match self {
+            StreamType::DataFrame(_) => "arrow", // dataframe will be converted to arrow record batch
+            StreamType::BinStream(_) => "binary",
+        };
+        write!(f, "{}", desc)
+    }
+}
+
+async fn to_stream(
+    mut msg: Box<dyn Message>,
+) -> StreamType<impl Stream<Item = Result<Chunk, SectionError>>> {
+    let chunk = msg.next().await;
+    let is_df = matches!(chunk, Ok(Some(Chunk::DataFrame(_))));
+    let stream = stream! {
+        match chunk {
+            Ok(Some(v)) => yield Ok(v),
+            Err(e) => yield Err(e),
+            Ok(None) => return
+        }
+        loop {
+            match msg.next().await {
+                Ok(Some(v)) => yield Ok(v),
+                Err(e) => yield Err(e),
+                Ok(None) => return
+            }
+        }
+    };
+    match is_df {
+        true => StreamType::DataFrame(stream),
+        false => StreamType::BinStream(stream),
+    }
 }
 
 struct S<T: Stream> {
@@ -42,31 +92,6 @@ impl<T: Stream> Stream for S<T> {
             Stream::poll_next(Pin::new_unchecked(&mut this.inner), cx)
         }
     }
-}
-
-async fn to_stream(
-    mut msg: Box<dyn Message>,
-) -> (StreamType, impl Stream<Item = Result<Chunk, SectionError>>) {
-    let chunk = msg.next().await;
-    let stream_type = match chunk {
-        Ok(Some(Chunk::DataFrame(_))) => StreamType::DataFrame,
-        _ => StreamType::BinStream,
-    };
-    let stream = stream! {
-        match chunk {
-            Ok(Some(v)) => yield Ok(v),
-            Err(e) => yield Err(e),
-            Ok(None) => return
-        }
-        loop {
-            match msg.next().await {
-                Ok(Some(v)) => yield Ok(v),
-                Err(e) => yield Err(e),
-                Ok(None) => return
-            }
-        }
-    };
-    (stream_type, stream)
 }
 
 impl Mycelial {
@@ -110,8 +135,10 @@ impl Mycelial {
                     };
                     let origin = msg.origin().to_string();
                     let ack = msg.ack();
-                    let (stream_type, msg_stream) = to_stream(msg).await;
+                    let msg_stream = to_stream(msg).await;
+                    let stream_type = msg_stream.to_string();
                     let msg_stream = msg_stream
+                        .into_inner()
                         .map_ok(|chunk| {
                             match chunk {
                                 Chunk::DataFrame(df) => {
@@ -135,7 +162,7 @@ impl Mycelial {
                         ))
                         .header("Authorization", self.basic_auth())
                         .header("x-message-origin", origin)
-                        .header("x-stream-type", stream_type.to_string())
+                        .header("x-stream-type", stream_type)
                         .body(body)
                         .send()
                         .await?;

--- a/pipe/section/section_impls/mycelial_server/src/lib.rs
+++ b/pipe/section/section_impls/mycelial_server/src/lib.rs
@@ -1,21 +1,2 @@
 pub mod destination;
 pub mod source;
-
-use std::fmt::Display;
-
-// should we just introduce additional method in message trait to indicate stream type?
-#[derive(Debug)]
-pub(crate) enum StreamType {
-    DataFrame,
-    BinStream,
-}
-
-impl Display for StreamType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let desc = match self {
-            StreamType::DataFrame => "arrow", // dataframe will be converted to arrow record batch
-            StreamType::BinStream => "binary",
-        };
-        write!(f, "{}", desc)
-    }
-}

--- a/pipe/section/section_impls/mycelial_server/src/lib.rs
+++ b/pipe/section/section_impls/mycelial_server/src/lib.rs
@@ -1,2 +1,21 @@
 pub mod destination;
 pub mod source;
+
+use std::fmt::Display;
+
+// should we just introduce additional method in message trait to indicate stream type?
+#[derive(Debug)]
+pub(crate) enum StreamType {
+    DataFrame,
+    BinStream,
+}
+
+impl Display for StreamType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let desc = match self {
+            StreamType::DataFrame => "arrow", // dataframe will be converted to arrow record batch
+            StreamType::BinStream => "binary",
+        };
+        write!(f, "{}", desc)
+    }
+}

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -27,6 +27,7 @@ pretty_env_logger = "0.5"
 common = { path = "../common" }
 rust-embed = "8.0.0"
 mime_guess = { version = "2" }
+async-stream = "0.3.5"
 
 [dependencies.uuid]
 version = "1.4.0"

--- a/server/migrations/20240119145229_message_stream_type.sql
+++ b/server/migrations/20240119145229_message_stream_type.sql
@@ -1,0 +1,11 @@
+-- Add stream_type indication && update all previous records to 'arrow'
+ALTER TABLE messages ADD COLUMN stream_type TEXT;
+UPDATE messages SET stream_type = 'arrow';
+
+-- Fix issue with message_id type
+ALTER TABLE records ADD COLUMN message_id_ INTEGER;
+UPDATE records SET message_id_ = message_id;
+DROP INDEX message_id_idx;
+ALTER TABLE records DROP COLUMN message_id;
+ALTER TABLE records RENAME COLUMN message_id_ TO message_id;
+CREATE INDEX message_id_idx ON records(message_id);

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -476,14 +476,15 @@ impl Database {
         origin: &str,
         stream_type: &str,
     ) -> Result<i64, error::Error> {
-        let id =
-            sqlx::query("INSERT INTO messages(topic, origin, stream_type) VALUES(?, ?, ?) RETURNING ID")
-                .bind(topic)
-                .bind(origin)
-                .bind(stream_type)
-                .fetch_one(&mut **transaction)
-                .await
-                .map(|row| row.get::<i64, _>(0))?;
+        let id = sqlx::query(
+            "INSERT INTO messages(topic, origin, stream_type) VALUES(?, ?, ?) RETURNING ID",
+        )
+        .bind(topic)
+        .bind(origin)
+        .bind(stream_type)
+        .fetch_one(&mut **transaction)
+        .await
+        .map(|row| row.get::<i64, _>(0))?;
         Ok(id)
     }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,7 +1,3 @@
-use arrow::{
-    ipc::{reader::StreamReader, writer::StreamWriter},
-    record_batch::RecordBatch,
-};
 use axum::{
     body::StreamBody,
     extract::{BodyStream, State},
@@ -19,7 +15,7 @@ use common::{
     Destination, IssueTokenRequest, IssueTokenResponse, PipeConfig, PipeConfigs,
     ProvisionClientRequest, ProvisionClientResponse, Source,
 };
-use futures::StreamExt;
+use futures::{Stream, StreamExt};
 use rust_embed::RustEmbed;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -27,7 +23,8 @@ use sqlx::{
     sqlite::SqliteConnectOptions, sqlite::SqliteRow, ConnectOptions, Connection, FromRow, Row,
     Sqlite, SqliteConnection, Transaction,
 };
-use std::{convert::Infallible, io::Cursor, net::SocketAddr, path::Path};
+use std::pin::Pin;
+use std::{net::SocketAddr, path::Path};
 use std::{str::FromStr, sync::Arc};
 use tokio::sync::{Mutex, MutexGuard};
 use uuid::Uuid;
@@ -85,30 +82,31 @@ async fn ingestion(
         None => Err(StatusCode::BAD_REQUEST)?,
     };
 
-    let mut buf = vec![];
-    while let Some(chunk) = body.next().await {
-        buf.append(&mut chunk.unwrap().to_vec());
-    }
-    let ln = buf.len() as u64;
-    let mut buf = Cursor::new(buf);
+    let stream_type = match headers.get("x-stream-type") {
+        Some(origin) => origin
+            .to_str()
+            .map_err(|_| "bad x-message-origin header value")?,
+        None => "dataframe", // by default
+    };
+
     let mut connection = app.database.get_connection().await;
     let mut transaction = connection.begin().await?;
+
     let message_id = app
         .database
-        .new_message(&mut transaction, topic.as_str(), origin)
+        .new_message(&mut transaction, topic.as_str(), origin, stream_type)
         .await?;
+
     let mut stored = 0;
-    while buf.position() < ln {
-        let reader = StreamReader::try_new_unbuffered(&mut buf, None).unwrap();
-        for record_batch in reader {
-            let record_batch = record_batch?;
-            app.database
-                .store_batch(&mut transaction, message_id, &record_batch)
-                .await?;
-            stored += 1;
-        }
+    while let Some(chunk) = body.next().await {
+        // FIXME: accumulate into buffer
+        let chunk = chunk?;
+        app.database
+            .store_chunk(&mut transaction, message_id, chunk.as_ref())
+            .await?;
+        stored += 1;
     }
-    // don't store messages without batches
+    // don't store empty messages
     match stored {
         0 => transaction.rollback().await?,
         _ => transaction.commit().await?,
@@ -121,24 +119,26 @@ async fn get_message(
     axum::extract::Path((topic, offset)): axum::extract::Path<(String, u64)>,
 ) -> Result<impl IntoResponse, error::Error> {
     let response = match app.database.get_message(&topic, offset).await? {
-        batches if batches.is_empty() => (
-            [
-                ("x-message-id", offset.to_string()),
-                ("x-message-origin", String::new()),
-            ],
-            StreamBody::new(futures::stream::iter(vec![])),
-        ),
-        batches => {
-            let (id, origin, _) = batches.first().unwrap();
-            let id = id.to_string();
-            let origin = origin.to_string();
-            let chunks: Vec<Result<_, Infallible>> =
-                batches.into_iter().map(|(_, _, data)| Ok(data)).collect();
+        None => {
+            let stream: Pin<Box<dyn Stream<Item = _> + Send>> =
+                Box::pin(futures::stream::empty::<Result<Vec<u8>, error::Error>>());
             (
-                [("x-message-id", id), ("x-message-origin", origin)],
-                StreamBody::new(futures::stream::iter(chunks)),
+                [
+                    ("x-message-id", offset.to_string()),
+                    ("x-message-origin", "".into()),
+                    ("x-stream-type", "".into()),
+                ],
+                StreamBody::new(stream),
             )
         }
+        Some((id, origin, stream_type, stream)) => (
+            [
+                ("x-message-id", id.to_string()),
+                ("x-message-origin", origin),
+                ("x-stream-type", stream_type),
+            ],
+            StreamBody::new(stream),
+        ),
     };
     Ok(response)
 }
@@ -474,30 +474,25 @@ impl Database {
         transaction: &mut Transaction<'_, Sqlite>,
         topic: &str,
         origin: &str,
+        stream_type: &str,
     ) -> Result<i64, error::Error> {
-        let id = sqlx::query("INSERT INTO messages(topic, origin) VALUES(?, ?) RETURNING ID")
-            .bind(topic)
-            .bind(origin)
-            .fetch_one(&mut **transaction)
-            .await
-            .map(|row| row.get::<i64, _>(0))?;
+        let id =
+            sqlx::query("INSERT INTO messages(topic, origin, stream_type) VALUES(?, ?, ?) RETURNING ID")
+                .bind(topic)
+                .bind(origin)
+                .bind(stream_type)
+                .fetch_one(&mut **transaction)
+                .await
+                .map(|row| row.get::<i64, _>(0))?;
         Ok(id)
     }
 
-    async fn store_batch(
+    async fn store_chunk(
         &self,
         transaction: &mut Transaction<'_, Sqlite>,
         message_id: i64,
-        record_batch: &RecordBatch,
+        bytes: &[u8],
     ) -> Result<(), error::Error> {
-        let mut stream_writer: StreamWriter<_> =
-            StreamWriter::try_new(vec![], record_batch.schema().as_ref()).unwrap();
-
-        // FIXME: unwrap
-        stream_writer.write(record_batch).unwrap();
-        stream_writer.finish().unwrap();
-
-        let bytes: Vec<u8> = stream_writer.into_inner().unwrap();
         sqlx::query("INSERT INTO records (message_id, data) VALUES (?, ?)")
             .bind(message_id)
             .bind(bytes)
@@ -511,27 +506,57 @@ impl Database {
         &self,
         topic: &str,
         offset: u64,
-    ) -> Result<Vec<(u64, String, Vec<u8>)>, error::Error> {
-        let mut connection = self.connection.lock().await;
+    ) -> Result<
+        Option<(
+            u64,
+            String,
+            String,
+            Pin<Box<dyn Stream<Item = Result<Vec<u8>, error::Error>> + Send>>,
+        )>,
+        error::Error,
+    > {
+        let mut connection = Arc::clone(&self.connection).lock_owned().await;
         let offset: i64 = offset.try_into().unwrap();
-        let rows = sqlx::query(
-            "WITH next_message AS ( SELECT id, topic, origin FROM messages WHERE id > ? and topic = ? LIMIT 1) \
-            SELECT n.id, n.origin, r.data FROM next_message n \
-            JOIN records r on n.id = r.message_id \
-            ORDER BY r.id"
+        let message_info = sqlx::query(
+            "SELECT id, origin, stream_type FROM messages WHERE id > ? and topic = ? LIMIT 1",
         )
-            .bind(offset)
-            .bind(topic)
-            .fetch_all(&mut *connection)
-            .await?
-            .into_iter()
-            .map(|row| (
-                row.get::<i64, &str>("id").try_into().unwrap(),
-                row.get("origin"),
-                row.get("data"),
-            ))
-            .collect::<Vec<_>>();
-        Ok(rows)
+        .bind(offset)
+        .bind(topic)
+        .fetch_optional(&mut *connection)
+        .await?
+        .map(|row| {
+            (
+                row.get::<i64, _>(0) as u64,
+                row.get::<String, _>(1),
+                row.get::<String, _>(2),
+            )
+        });
+
+        let (message_id, message_origin, message_type) = match message_info {
+            Some((id, o, t)) => (id, o, t),
+            None => return Ok(None),
+        };
+
+        // move connection into stream wrapper around sqlx's stream
+        let stream = async_stream::stream! {
+            let mut stream = sqlx::query("SELECT data FROM records r WHERE r.message_id = ?")
+                .bind(message_id as i64)
+                .fetch(&mut *connection)
+                .map(|maybe_row| {
+                    maybe_row
+                        .map(|row| row.get::<Vec<u8>, &str>("data"))
+                        .map_err(Into::into)
+                });
+            while let Some(chunk) = stream.next().await {
+                yield chunk;
+            }
+        };
+        Ok(Some((
+            message_id,
+            message_origin,
+            message_type,
+            Box::pin(stream),
+        )))
     }
 
     async fn get_clients(&self) -> Result<Clients, error::Error> {


### PR DESCRIPTION
Adds support for myc messages with binary payload.
New header `x-stream-type` header introduced to indicate message type.
Fixes issue with last migration for `messages.message_id` column