### PR TITLE
Alex/fix fields in new frontend

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -38,7 +38,7 @@ pub struct Node {
 pub enum Source {
     Sqlite_Connector(SqliteSourceConfig),
     Kafka(KafkaConfig),
-    Snowflake(SnowflakeDestinationConfig),
+    Snowflake(SnowflakeSourceConfig),
     Sqlite_Physical_Replication(SqlitePhysicalReplicationSourceConfig),
     Hello_World(HelloWorldSourceConfig),
     Excel_Connector(ExcelConfig),

--- a/console/src/components/NodeForm.tsx
+++ b/console/src/components/NodeForm.tsx
@@ -25,7 +25,8 @@ const NodeForm = () => {
     clientName,
     source,
     destination,
-    password,
+    name, 
+    client, // todo
     ...fields
   } = activeNode?.data ?? {};
 

--- a/console/src/components/NodeFormField.tsx
+++ b/console/src/components/NodeFormField.tsx
@@ -11,10 +11,12 @@ type NodeFormFieldProps = {
   formik: any;
 };
 const renderNodeFormField = ({ key, formik }: NodeFormFieldProps) => {
-  console.log({ key });
-  console.log({ formik });
+  let fieldType: string = fieldNames[key] as string;
+  if (fieldType === undefined) {
+    console.warn(`No field type found for ${key}`);
+    fieldType = 'text';
+  }
 
-  const fieldType: string = fieldNames[key] as string;
   switch (fieldType) {
     case 'number':
     case 'text':

--- a/console/src/utils/constants.ts
+++ b/console/src/utils/constants.ts
@@ -73,6 +73,14 @@ export const fieldNames: { [key: string]: string } = {
   schema: 'text',
   database: 'text',
   tables: 'text',
+  password: 'text',
+  username: 'text',
+  account_identifier: 'text',
+  query: 'text',
+  poll_interval: 'number',
+  delay: 'number',
+  text: 'text',
+  column: 'text',
 };
 
 export const mycelialServer = {


### PR DESCRIPTION
Not all the fields were showing up  in the frontend because the field names weren't listed in `fieldNames`. Overall I think this approach is probably not sustainable long-term, for a variety of reasons*, but this is good enough to unbreak it for now.


*we already have the type info on the backend, so we should be able to use that (e.g. maybe we can generate the typescript types automatically from our rust code). It is also possible that a field is supposed to be one type in one section but another type in another section, which wouldn't work in the current implementation.