### PR TITLE
Query based mysql connector

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -208,8 +208,8 @@ pub struct MysqlConnectorSourceConfig {
     #[serde(flatten)]
     pub common_attrs: CommonAttrs,
     pub url: String,
-    pub schema: String,
-    pub tables: String,
+    pub origin: String,
+    pub query: String,
     pub poll_interval: i64,
 }
 
@@ -225,6 +225,7 @@ pub struct MysqlConnectorDestinationConfig {
     #[serde(flatten)]
     pub common_attrs: CommonAttrs,
     pub url: String,
+    pub truncate: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]

--- a/myceliald/config.example.toml
+++ b/myceliald/config.example.toml
@@ -53,7 +53,7 @@ display_name = "Tagging Transformer"
 type = "typecast_transformer"
 display_name = "Typecast Transformer"
 from = "any"
-to = "string"
+target_type = "string"
 column = "name"
 
 [[sources]]
@@ -129,15 +129,16 @@ url = "postgres://user:password@127.0.0.1:5432/test"
 [[sources]]
 type = "mysql_connector"
 display_name = "mysql source"
+origin = "test"
 url = "mysql://username:password@127.0.0.1:3306/test"
-schema = "test"
-tables = "*"
+query = "select * from test"
 poll_interval = 5
 
 [[destinations]]
 type = "mysql_connector"
 display_name = "mysql destination"
 url = "mysql://username:password@127.0.0.1:3306/test"
+truncate = false
 
 [[destinations]]
 type = "file"

--- a/pipe/section/section_impls/mysql_connector/src/lib.rs
+++ b/pipe/section/section_impls/mysql_connector/src/lib.rs
@@ -4,31 +4,30 @@ use section::{
     message::{Ack, Chunk, Column, DataFrame, DataType, Message, Value},
     SectionError,
 };
+use tokio::sync::mpsc::Receiver;
 
 pub mod destination;
 pub mod source;
 
 #[derive(Debug)]
-#[allow(unused)]
-pub(crate) struct Table {
-    name: Arc<str>,
-    columns: Arc<[TableColumn]>,
-    query: String,
-    offset: i64,
-    limit: i64,
-}
-
-#[derive(Debug)]
-#[allow(unused)]
-pub(crate) struct TableColumn {
-    name: Arc<str>,
+pub(crate) struct MysqlColumn {
+    name: String,
     data_type: DataType,
 }
 
-#[derive(Debug, Clone)]
+impl MysqlColumn {
+    fn new(name: impl Into<String>, data_type: DataType) -> Self {
+        Self {
+            name: name.into(),
+            data_type,
+        }
+    }
+}
+
+#[derive(Debug)]
 pub struct MysqlPayload {
     /// column names
-    columns: Arc<[TableColumn]>,
+    columns: Vec<MysqlColumn>,
 
     /// values
     values: Vec<Vec<Value>>,
@@ -52,17 +51,12 @@ impl DataFrame for MysqlPayload {
 
 pub struct MysqlMessage {
     origin: Arc<str>,
-    payload: Option<Box<dyn DataFrame>>,
-    ack: Option<Ack>,
+    stream: Receiver<Result<Chunk, SectionError>>,
 }
 
 impl MysqlMessage {
-    fn new(origin: Arc<str>, payload: impl DataFrame, ack: Option<Ack>) -> Self {
-        Self {
-            origin,
-            payload: Some(Box::new(payload)),
-            ack,
-        }
+    fn new(origin: Arc<str>, stream: Receiver<Result<Chunk, SectionError>>) -> Self {
+        Self { origin, stream }
     }
 }
 
@@ -70,7 +64,6 @@ impl std::fmt::Debug for MysqlMessage {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MysqlMessage")
             .field("origin", &self.origin)
-            .field("payload", &self.payload)
             .finish()
     }
 }
@@ -81,12 +74,17 @@ impl Message for MysqlMessage {
     }
 
     fn next(&mut self) -> section::message::Next<'_> {
-        let v = self.payload.take().map(Chunk::DataFrame);
-        Box::pin(async move { Ok(v) })
+        Box::pin(async move {
+            match self.stream.recv().await {
+                Some(Ok(df)) => Ok(Some(df)),
+                Some(Err(e)) => Err(e),
+                None => Ok(None),
+            }
+        })
     }
 
     fn ack(&mut self) -> Ack {
-        self.ack.take().unwrap_or(Box::pin(async {}))
+        Box::pin(async {})
     }
 }
 
@@ -112,9 +110,15 @@ pub fn generate_schema(table_name: &str, df: &dyn DataFrame) -> Result<String, S
         .iter()
         .map(|col| {
             let dtype = match col.data_type() {
-                DataType::I8 | DataType::I16 => "SMALLINT",
+                DataType::Bool => "TINYINT",
+                DataType::I8 => "TINYINT",
+                DataType::I16 => "SMALLINT",
                 DataType::I32 => "INTEGER",
                 DataType::I64 => "BIGINT",
+                DataType::U8 => "TINYINT UNSIGNED",
+                DataType::U16 => "SMALLINT UNSIGNED",
+                DataType::U32 => "INT UNSIGNED",
+                DataType::U64 => "BIGINT UNSIGNED",
                 DataType::F32 => "REAL",
                 DataType::F64 => "DOUBLE",
                 DataType::Decimal => "NUMERIC",
@@ -123,16 +127,10 @@ pub fn generate_schema(table_name: &str, df: &dyn DataFrame) -> Result<String, S
                 DataType::Bin => "BLOB",
                 DataType::Time(_) => "TIME",
                 DataType::Date(_) => "DATE",
-                DataType::TimeStamp(_) => "TIMESTAMP",
-                DataType::TimeStampUTC(_) => "TIMESTAMP",
+                DataType::TimeStamp(_) => "DATETIME",
+                DataType::TimeStampUTC(_) => "DATETIME",
                 DataType::Uuid => "UUID",
-                DataType::Bool => "TINYINT",
-                DataType::U8 => "SMALLINT",
-                DataType::U16 => "INT",
-                DataType::U32 => "BIGINT",
-                DataType::U64 => "DOUBLE",
-                DataType::Any => "TEXT", // I don't think this is fully valid but it kinda works?
-                v => return Err(format!("unsupported type {v:?}")),
+                v => return Err(format!("failed to generate schema, unsupported type {v:?}")),
             };
             Ok(format!("{} {}", col.name(), dtype))
         })

--- a/pipe/section/section_impls/mysql_connector/src/lib.rs
+++ b/pipe/section/section_impls/mysql_connector/src/lib.rs
@@ -121,7 +121,10 @@ pub fn generate_schema(table_name: &str, df: &dyn DataFrame) -> Result<String, S
                 DataType::U64 => "BIGINT UNSIGNED",
                 DataType::F32 => "REAL",
                 DataType::F64 => "DOUBLE",
-                DataType::Decimal => "NUMERIC",
+                // FIXME:
+                // 65 total len with 10 being used by scale
+                // in future we can have advanced section configuration for such values
+                DataType::Decimal => "NUMERIC(55, 10)",
                 DataType::RawJson => "JSON",
                 DataType::Str => "TEXT",
                 DataType::Bin => "BLOB",


### PR DESCRIPTION
- Source updates type match a bit (more types supported, proper match between integers both signed and unsigned)
- Destination allows truncation

## Demo
### Original table 
```
mysql> show create table test\G;
*************************** 1. row ***************************
       Table: test
Create Table: CREATE TABLE `test` (
  `u8` tinyint unsigned DEFAULT NULL,
  `u16` smallint unsigned DEFAULT NULL,
  `u32` int unsigned DEFAULT NULL,
  `u64` bigint unsigned DEFAULT NULL,
  `i8` tinyint DEFAULT NULL,
  `i16` smallint DEFAULT NULL,
  `i32` int DEFAULT NULL,
  `i64` bigint DEFAULT NULL,
  `ch` char(8) DEFAULT NULL,
  `vchar` varchar(255) DEFAULT NULL,
  `txt` text,
  `f32` float DEFAULT NULL,
  `f64` double DEFAULT NULL,
  `number` decimal(15,4) DEFAULT NULL,
  `bin` blob,
  `time` time DEFAULT NULL,
  `date` date DEFAULT NULL,
  `timestamp` timestamp NULL DEFAULT NULL,
  `datetime` datetime DEFAULT NULL,
  `year` year DEFAULT NULL,
  `json` json DEFAULT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
1 row in set (0.00 sec)
```
```
mysql> select * from test\G;
*************************** 1. row ***************************
       u8: 8
      u16: 16
      u32: 32
      u64: 64
       i8: -8
      i16: -16
      i32: -32
      i64: -64
       ch: char
    vchar: varchar
      txt: some text
      f32: 3.2
      f64: 6.4
   number: 100.5000
      bin: 0x62696E
     time: 08:40:00
     date: 2020-01-01
timestamp: 1970-01-01 00:00:01
 datetime: 2020-01-01 08:40:01
     year: 1980
     json: {"foo": "bar"}
1 row in set (0.00 sec)
```
### Destination
```
mysql> show create table replica.test\G;
*************************** 1. row ***************************
       Table: test
Create Table: CREATE TABLE `test` (
  `u8` tinyint unsigned DEFAULT NULL,
  `u16` smallint unsigned DEFAULT NULL,
  `u32` int unsigned DEFAULT NULL,
  `u64` bigint unsigned DEFAULT NULL,
  `i8` tinyint DEFAULT NULL,
  `i16` smallint DEFAULT NULL,
  `i32` int DEFAULT NULL,
  `i64` bigint DEFAULT NULL,
  `ch` text,
  `vchar` text,
  `txt` text,
  `f32` double DEFAULT NULL,
  `f64` double DEFAULT NULL,
  `number` decimal(55,10) DEFAULT NULL,
  `bin` blob,
  `time` time DEFAULT NULL,
  `date` date DEFAULT NULL,
  `timestamp` datetime DEFAULT NULL,
  `datetime` datetime DEFAULT NULL,
  `year` int unsigned DEFAULT NULL,
  `json` json DEFAULT NULL
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
1 row in set (0.00 sec)
```

```
mysql> select * from replica.test\G;
*************************** 1. row ***************************
       u8: 8
      u16: 16
      u32: 32
      u64: 64
       i8: -8
      i16: -16
      i32: -32
      i64: -64
       ch: char
    vchar: varchar
      txt: some text
      f32: 3.200000047683716
      f64: 6.4
   number: 100.5000000000
      bin: 0x62696E
     time: 08:40:00
     date: 2020-01-01
timestamp: 1970-01-01 00:00:01
 datetime: 2020-01-01 08:40:01
     year: 1980
     json: {"foo": "bar"}
1 row in set (0.00 sec)
```

