### PR TITLE
Sqlite destination dogfood fixes

### DIFF
--- a/pipe/section/section_impls/sqlite_connector/src/destination.rs
+++ b/pipe/section/section_impls/sqlite_connector/src/destination.rs
@@ -7,7 +7,7 @@ use section::{
 };
 use std::pin::{pin, Pin};
 
-use crate::{escape_table_name, generate_schema};
+use crate::{escape_table_name, generate_schema, generate_column_names};
 use sqlx::types::chrono::NaiveDateTime;
 use sqlx::{sqlite::SqliteConnectOptions, ConnectOptions};
 use std::future::Future;
@@ -87,7 +87,8 @@ impl Sqlite {
                                             .await?;
                                     }
                                     let values_placeholder = (0..columns.len()).map(|_| "?").collect::<Vec<_>>().join(",");
-                                    insert_query = format!("INSERT OR IGNORE INTO \"{name}\" VALUES({values_placeholder})");
+                                    let columns = generate_column_names(df.as_ref());
+                                    insert_query = format!("INSERT OR IGNORE INTO \"{name}\" ({columns}) VALUES({values_placeholder})");
                                 }
                                 'outer: loop {
                                     let mut query = sqlx::query(&insert_query);

--- a/pipe/section/section_impls/sqlite_connector/src/destination.rs
+++ b/pipe/section/section_impls/sqlite_connector/src/destination.rs
@@ -7,7 +7,7 @@ use section::{
 };
 use std::pin::{pin, Pin};
 
-use crate::{escape_table_name, generate_schema, generate_column_names};
+use crate::{escape_table_name, generate_column_names, generate_schema};
 use sqlx::types::chrono::NaiveDateTime;
 use sqlx::{sqlite::SqliteConnectOptions, ConnectOptions};
 use std::future::Future;

--- a/pipe/section/section_impls/sqlite_connector/src/lib.rs
+++ b/pipe/section/section_impls/sqlite_connector/src/lib.rs
@@ -112,8 +112,7 @@ pub fn generate_schema(table_name: &str, df: &dyn DataFrame) -> String {
 }
 
 pub fn generate_column_names(df: &dyn DataFrame) -> String {
-    let columns = df
-        .columns()
+    df.columns()
         .iter()
         .map(|col| col.name())
         .map(|name| {
@@ -125,6 +124,5 @@ pub fn generate_column_names(df: &dyn DataFrame) -> String {
             format!("\"{}\"", name)
         })
         .collect::<Vec<_>>()
-        .join(",");
-    columns
+        .join(",")
 }

--- a/pipe/section/section_impls/sqlite_connector/src/lib.rs
+++ b/pipe/section/section_impls/sqlite_connector/src/lib.rs
@@ -107,11 +107,24 @@ pub fn escape_table_name(name: impl AsRef<str>) -> String {
 /// generate create table command for provided record batch
 pub fn generate_schema(table_name: &str, df: &dyn DataFrame) -> String {
     let name = escape_table_name(table_name);
+    let columns = generate_column_names(df);
+    format!("CREATE TABLE IF NOT EXISTS \"{name}\" ({columns})",)
+}
+
+pub fn generate_column_names(df: &dyn DataFrame) -> String {
     let columns = df
         .columns()
         .iter()
         .map(|col| col.name())
+        .map(|name| {
+            // escape all quotes by replacing with a double quote
+            name.replace("\"", "\"\"")
+        })
+        .map(|name| {
+            // wrap the name in quotes
+            format!("\"{}\"", name)
+        })
         .collect::<Vec<_>>()
         .join(",");
-    format!("CREATE TABLE IF NOT EXISTS \"{name}\" ({columns})",)
+    columns
 }

--- a/pipe/section/section_impls/sqlite_connector/src/lib.rs
+++ b/pipe/section/section_impls/sqlite_connector/src/lib.rs
@@ -118,7 +118,7 @@ pub fn generate_column_names(df: &dyn DataFrame) -> String {
         .map(|col| col.name())
         .map(|name| {
             // escape all quotes by replacing with a double quote
-            name.replace("\"", "\"\"")
+            name.replace('\"', "\"\"")
         })
         .map(|name| {
             // wrap the name in quotes

--- a/pipe/section/section_impls/sqlite_connector/src/lib.rs
+++ b/pipe/section/section_impls/sqlite_connector/src/lib.rs
@@ -116,12 +116,9 @@ pub fn generate_column_names(df: &dyn DataFrame) -> String {
         .iter()
         .map(|col| col.name())
         .map(|name| {
-            // escape all quotes by replacing with a double quote
-            name.replace('\"', "\"\"")
-        })
-        .map(|name| {
             // wrap the name in quotes
-            format!("\"{}\"", name)
+            // escape all quotes by replacing with a double quote
+            format!("\"{}\"", name.replace('\"', "\"\""))
         })
         .collect::<Vec<_>>()
         .join(",")


### PR DESCRIPTION
Found a few issues connecting excel -> sqlite, and these changes are the result.
1) If a column name is a number, it has to be in quotes.
2) If a column name has spaces in it, the table will be created correctly, but you can't select values from the table using that name unless it has quotes.
3) sqlite reserved keywords can be used as column names, but they must be enclosed in quotes.
4) therefore, all sqlite column names will now be enclosed in quotes. 
5) If there are quotes in the column name, those are escaped with extra quotes so that they're preserved.
6) Add column names to the `INSERT` query, so that if columns are moved around in an excel sheet, the values don't get all swapped around. 