### PR TITLE
Daemon refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1442,16 +1442,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a009aa4810eb158359dda09d0c87378e4bbb89b5a801f016885a4707ba24f7ea"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
 name = "env_logger"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1472,19 +1462,6 @@ dependencies = [
  "log",
  "regex",
  "termcolor",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c012a26a7f605efc424dd53697843a72be7dc86ad2d01f7814337794a12231d"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "humantime",
- "log",
 ]
 
 [[package]]
@@ -2462,7 +2439,6 @@ dependencies = [
  "base64 0.21.5",
  "clap",
  "common",
- "env_logger 0.11.2",
  "excel_connector",
  "file",
  "hello_world",
@@ -2483,6 +2459,8 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
+ "tracing",
+ "tracing-subscriber",
  "typecast_transformer",
 ]
 
@@ -2552,6 +2530,16 @@ dependencies = [
  "mio",
  "walkdir",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
 ]
 
 [[package]]
@@ -2775,6 +2763,12 @@ checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -3753,6 +3747,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4345,6 +4348,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "thrift"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4611,6 +4624,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -4748,6 +4787,12 @@ dependencies = [
  "quote",
  "syn 2.0.48",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1328,6 +1328,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "176dc175b78f56c0f321911d9c8eb2b77a78a4860b9c19db83835fea1a46649b"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,19 +1461,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1529,6 +1525,15 @@ dependencies = [
  "section",
  "tempfile",
  "tokio",
+]
+
+[[package]]
+name = "file-id"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6584280525fb2059cba3db2c04abf947a1a29a45ddae89f3870f8281704fafc9"
+dependencies = [
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1608,6 +1613,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2109,17 +2123,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
-name = "is-terminal"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
-dependencies = [
- "hermit-abi",
- "rustix",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "itertools"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2446,17 +2449,19 @@ dependencies = [
  "log",
  "mycelial_server",
  "mysql_connector",
+ "notify",
+ "notify-debouncer-full",
  "postgres_connector",
  "reqwest",
  "runtime",
  "section",
  "serde",
  "serde_json",
+ "sha2",
  "snowflake",
  "sqlite_connector",
  "sqlx",
  "tagging_transformer",
- "thiserror",
  "tokio",
  "toml",
  "tracing",
@@ -2522,7 +2527,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
 dependencies = [
  "bitflags 2.4.1",
+ "crossbeam-channel",
  "filetime",
+ "fsevent-sys",
  "inotify",
  "kqueue",
  "libc",
@@ -2530,6 +2537,20 @@ dependencies = [
  "mio",
  "walkdir",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f5dab59c348b9b50cf7f261960a20e389feb2713636399cd9082cd4b536154"
+dependencies = [
+ "crossbeam-channel",
+ "file-id",
+ "log",
+ "notify",
+ "parking_lot 0.12.1",
+ "walkdir",
 ]
 
 [[package]]
@@ -2975,16 +2996,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "pretty_env_logger"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
-dependencies = [
- "env_logger 0.10.1",
- "log",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3082,7 +3093,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
- "env_logger 0.8.4",
+ "env_logger",
  "log",
  "rand",
 ]
@@ -3710,9 +3721,7 @@ dependencies = [
  "common",
  "futures",
  "jsonwebtoken 9.2.0",
- "log",
  "mime_guess",
- "pretty_env_logger",
  "reqwest",
  "rust-embed",
  "serde",
@@ -3721,6 +3730,8 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tower-http",
+ "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 
@@ -4316,15 +4327,6 @@ dependencies = [
  "redox_syscall 0.4.1",
  "rustix",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,3 +1,7 @@
+// FIXME:  drop this crate
+// - sharing same structs between server and daemon is not a good idea, especially if we want to
+// support versioned API and allow older daemons to communicate with newer server
+// - section configuration should be property of section library
 use pipe::config::{Config as DynamicPipeConfig, Value as DynamicPipeValue};
 use section::SectionError;
 use serde::{Deserialize, Serialize};
@@ -25,9 +29,12 @@ pub struct Server {
 /// Generic node config
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Node {
+    // FIXME: that's property of control plane
     pub display_name: String,
+    // FIXME: that's property of control plane
     pub unique_id: String,
     pub storage_path: String,
+    // FIXME: why auth_token is here and not in Server section?
     pub auth_token: String,
 }
 
@@ -242,15 +249,17 @@ pub struct FileDestinationConfig {
 
 // requests and responses
 // todo: move to a module
-
+// FIXME: don't share daemon & server internals.
+// FIXME: redo provisioning
 #[derive(Serialize, Deserialize, Debug)]
-pub struct ProvisionClientRequest {
-    pub client_config: ClientConfig,
+pub struct ProvisionDaemonRequest {
+    // FIXME: unique_id/display_name properties of control plane
+    pub unique_id: String,
+    pub display_name: String,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct ProvisionClientResponse {
-    pub id: String,
+pub struct ProvisionDaemonResponse {
     pub client_id: String,
     pub client_secret: String,
 }
@@ -281,6 +290,7 @@ pub struct PipeConfig {
     /// To do that - each pipe config needs to be uniquely identified, so here is i64 integer to
     /// help with that. Signed due to Sqlite backed storage
     #[serde(default)]
+    // FIXME: try_from
     #[sqlx(try_from = "i32")]
     pub id: u64,
 
@@ -303,13 +313,16 @@ pub struct PipeConfig {
     ///         ]
     /// }]}
     /// ```
+    // FIXME: renaming
     #[sqlx(rename = "raw_config")]
     pub pipe: serde_json::Value,
+    // FIXME: default_id, try_from cast
     #[sqlx(try_from = "i64")]
     #[serde(default = "default_id")]
     pub workspace_id: u64,
 }
 
+// FIXME:
 fn default_id() -> u64 {
     1
 }

--- a/myceliald/.gitignore
+++ b/myceliald/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 *.sqlite
 *.db
+config.toml

--- a/myceliald/Cargo.toml
+++ b/myceliald/Cargo.toml
@@ -33,5 +33,6 @@ tagging_transformer = { path = "../pipe/section/section_impls/tagging_transforme
 typecast_transformer = { path = "../pipe/section/section_impls/typecast_transformer" }
 mysql_connector = { path = "../pipe/section/section_impls/mysql_connector/" }
 file = { path = "../pipe/section/section_impls/file/" }
-env_logger = "0.11.2"
+tracing = "0.1.40"
+tracing-subscriber = "0.3.18"
 #sqlite_physical_replication = { path = "../pipe/section/section_impls/sqlite_physical_replication/" }

--- a/myceliald/Cargo.toml
+++ b/myceliald/Cargo.toml
@@ -17,7 +17,6 @@ sqlx = { version = "0.7", features = ["sqlite"]}
 log = "0.4"
 toml = "0.7"
 common = { path = "../common" }
-thiserror = "1"
 pipe = { version = "0.3", path = "../pipe/runtime/", package="runtime" }
 section = { version = "0.3", path = "../pipe/section/" }
 
@@ -35,4 +34,7 @@ mysql_connector = { path = "../pipe/section/section_impls/mysql_connector/" }
 file = { path = "../pipe/section/section_impls/file/" }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
+notify = { version = "6.1.1", features = ["macos_kqueue"] }
+notify-debouncer-full = "0.3.1"
+sha2 = "0.10.8"
 #sqlite_physical_replication = { path = "../pipe/section/section_impls/sqlite_physical_replication/" }

--- a/myceliald/Makefile
+++ b/myceliald/Makefile
@@ -20,9 +20,11 @@ clean:
 
 .PHONY: dev
 dev:
-	RUST_LOG=$(RUST_LOG) cargo-watch -c -q \
-		-i myceliald_state.sqlite \
-		-i myceliald_state.sqlite-journal \
+	RUST_LOG=$(RUST_LOG) cargo-watch \
+		--why \
+		-i client.db \
+		-i client.db-journal \
+		-i config.toml \
 		-s 'cargo run -r -- --config=config.toml'
 
 .PHONY: vendor

--- a/myceliald/Makefile
+++ b/myceliald/Makefile
@@ -23,7 +23,7 @@ dev:
 	RUST_LOG=$(RUST_LOG) cargo-watch -c -q \
 		-i myceliald_state.sqlite \
 		-i myceliald_state.sqlite-journal \
-		-s 'cargo run -r -- --config=config.example.toml'
+		-s 'cargo run -r -- --config=config.toml'
 
 .PHONY: vendor
 vendor:

--- a/myceliald/config.example.toml
+++ b/myceliald/config.example.toml
@@ -122,6 +122,7 @@ account_identifier = "account_identifier"
 warehouse = "warehouse"
 database = "database"
 schema = "schema"
+truncate = true
 
 [[destinations]]
 type = "postgres_connector"

--- a/myceliald/migrations/20240304115513_connection.sql
+++ b/myceliald/migrations/20240304115513_connection.sql
@@ -1,0 +1,6 @@
+DROP TABLE client_creds;
+
+CREATE TABLE connection (
+    key text primary key,
+    value text
+);

--- a/myceliald/migrations/20240304135015_daemon.sql
+++ b/myceliald/migrations/20240304135015_daemon.sql
@@ -1,0 +1,4 @@
+CREATE TABLE daemon (
+    key text primary key,
+    value text
+);

--- a/myceliald/migrations/20240304155015_config.sql
+++ b/myceliald/migrations/20240304155015_config.sql
@@ -1,0 +1,4 @@
+CREATE TABLE config (
+    key text primary key,
+    value text
+);

--- a/myceliald/migrations/20240305120511_pipe.sql
+++ b/myceliald/migrations/20240305120511_pipe.sql
@@ -1,0 +1,4 @@
+CREATE TABLE pipe (
+    id int primary key,
+    config text
+);

--- a/myceliald/src/config_watcher.rs
+++ b/myceliald/src/config_watcher.rs
@@ -1,0 +1,185 @@
+use crate::DaemonMessage;
+
+use anyhow::Result;
+use notify::event::ModifyKind;
+use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use notify_debouncer_full::{new_debouncer, DebounceEventResult, Debouncer, FileIdMap};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use tokio::sync::{
+    mpsc::{channel, Receiver, Sender, UnboundedSender},
+    oneshot::{channel as oneshot_channel, Sender as OneshotSender},
+};
+
+#[derive(Debug)]
+pub struct ConfigWatcher {
+    config_path: PathBuf,
+    tx: UnboundedSender<DaemonMessage>,
+}
+
+#[derive(Debug)]
+pub enum ConfigWatcherEvent {
+    Modified,
+}
+
+enum FsEvent {
+    Modified,
+    Removed,
+    Error,
+}
+
+#[derive(Debug)]
+enum ConfigWatcherMessage {
+    Shutdown { reply_to: OneshotSender<()> },
+}
+
+// Track state of config watcher
+#[derive(Debug, PartialEq)]
+enum LastState {
+    Ok,
+    Failed,
+    ConfigRemoved,
+}
+
+impl ConfigWatcher {
+    fn new(config_path: &Path, tx: UnboundedSender<DaemonMessage>) -> Self {
+        Self {
+            config_path: config_path.into(),
+            tx,
+        }
+    }
+
+    fn spawn(self) -> ConfigWatcherHandle {
+        let (tx, mut rx) = channel(1);
+        tokio::spawn(async move { self.enter_loop(&mut rx).await });
+        ConfigWatcherHandle { tx }
+    }
+
+    async fn enter_loop(self, rx: &mut Receiver<ConfigWatcherMessage>) {
+        let mut maybe_debouncer = None;
+        let (watcher_tx, mut watcher_rx) = channel(1);
+        let mut last_state = LastState::Ok;
+        loop {
+            tokio::select! {
+                msg = rx.recv() => {
+                    match msg {
+                        None => {
+                            tracing::info!("handle was dropped, shutting down");
+                            return
+                        },
+                        Some(ConfigWatcherMessage::Shutdown{ reply_to }) => {
+                            tracing::info!("shutting down");
+                            if let Some(d) = maybe_debouncer.take() { d.stop_nonblocking() }
+                            reply_to.send(()).ok();
+                            return
+                        }
+                    }
+                },
+                _ = self.fs_events(&watcher_tx, &mut watcher_rx, &mut last_state, &mut maybe_debouncer) => {}
+            }
+        }
+    }
+
+    async fn fs_events(
+        &self,
+        tx: &Sender<FsEvent>,
+        rx: &mut Receiver<FsEvent>,
+        last_state: &mut LastState,
+        maybe_debouncer: &mut Option<Debouncer<RecommendedWatcher, FileIdMap>>,
+    ) {
+        *last_state = match maybe_debouncer.is_some() {
+            false => match self.init_debouncer(tx.clone()) {
+                Ok(d) => {
+                    tracing::info!("watching {:?}", self.config_path.as_path());
+                    *maybe_debouncer = Some(d);
+                    if last_state != &LastState::Ok {
+                        self.tx
+                            .send(DaemonMessage::ConfigWatcher(ConfigWatcherEvent::Modified))
+                            .ok();
+                    }
+                    LastState::Ok
+                }
+                Err(e) => {
+                    tracing::error!("failed to start fs watcher, error: {e:?}, retrying in 3 sec");
+                    tokio::time::sleep(Duration::from_secs(3)).await;
+                    LastState::Failed
+                }
+            },
+            true => match rx.recv().await {
+                None => {
+                    tracing::error!("fs watcher is down");
+                    maybe_debouncer.take();
+                    LastState::Failed
+                }
+                Some(event) => match event {
+                    FsEvent::Modified => {
+                        tracing::info!("config modified");
+                        self.tx
+                            .send(DaemonMessage::ConfigWatcher(ConfigWatcherEvent::Modified))
+                            .ok();
+                        LastState::Ok
+                    }
+                    FsEvent::Removed => {
+                        tracing::info!("config was removed");
+                        if let Some(d) = maybe_debouncer.take() { d.stop_nonblocking() }
+                        LastState::ConfigRemoved
+                    }
+                    FsEvent::Error => {
+                        tracing::info!("fs watcher encountered errors");
+                        if let Some(d) = maybe_debouncer.take() { d.stop_nonblocking() }
+                        LastState::Failed
+                    }
+                },
+            },
+        }
+    }
+
+    fn init_debouncer(
+        &self,
+        tx: Sender<FsEvent>,
+    ) -> Result<Debouncer<RecommendedWatcher, FileIdMap>> {
+        let event_handler = move |events: DebounceEventResult| {
+            match events {
+                Ok(events) => {
+                    let config_removed = events.into_iter().any(|event| {
+                        matches!(event.event.kind, EventKind::Modify(ModifyKind::Name(_)))
+                            || matches!(event.event.kind, EventKind::Remove(_))
+                    });
+                    // config file was removed, drop sender to re-initialize file watcher
+                    let event = match config_removed {
+                        true => FsEvent::Removed,
+                        false => FsEvent::Modified,
+                    };
+                    tx.blocking_send(event).ok();
+                }
+                Err(errors) => {
+                    tracing::error!("fs watcher errors: {:?}", errors);
+                    tx.blocking_send(FsEvent::Error).ok();
+                }
+            }
+        };
+        let mut debouncer = new_debouncer(Duration::from_secs(1), None, event_handler)?;
+        debouncer
+            .watcher()
+            .watch(self.config_path.as_path(), RecursiveMode::NonRecursive)?;
+        Ok(debouncer)
+    }
+}
+
+#[derive(Debug)]
+pub struct ConfigWatcherHandle {
+    tx: Sender<ConfigWatcherMessage>,
+}
+
+impl ConfigWatcherHandle {
+    pub async fn shutdown(&self) -> anyhow::Result<()> {
+        let (reply_to, rx) = oneshot_channel();
+        let message = ConfigWatcherMessage::Shutdown { reply_to };
+        self.tx.send(message).await?;
+        Ok(rx.await?)
+    }
+}
+
+pub fn new(path: &Path, tx: UnboundedSender<DaemonMessage>) -> ConfigWatcherHandle {
+    ConfigWatcher::new(path, tx).spawn()
+}

--- a/myceliald/src/config_watcher.rs
+++ b/myceliald/src/config_watcher.rs
@@ -121,12 +121,16 @@ impl ConfigWatcher {
                     }
                     FsEvent::Removed => {
                         tracing::info!("config was removed");
-                        if let Some(d) = maybe_debouncer.take() { d.stop_nonblocking() }
+                        if let Some(d) = maybe_debouncer.take() {
+                            d.stop_nonblocking()
+                        }
                         LastState::ConfigRemoved
                     }
                     FsEvent::Error => {
                         tracing::info!("fs watcher encountered errors");
-                        if let Some(d) = maybe_debouncer.take() { d.stop_nonblocking() }
+                        if let Some(d) = maybe_debouncer.take() {
+                            d.stop_nonblocking()
+                        }
                         LastState::Failed
                     }
                 },

--- a/myceliald/src/daemon_storage.rs
+++ b/myceliald/src/daemon_storage.rs
@@ -229,7 +229,7 @@ impl DaemonStorage {
 
     pub async fn reset_state(&mut self) -> anyhow::Result<()> {
         let queries = &[
-            "DELETE FROM connections",
+            "DELETE FROM connection",
             "DELETE FROM daemon",
             "DELETE FROM config",
             "DELETE FROM pipe",

--- a/myceliald/src/daemon_storage.rs
+++ b/myceliald/src/daemon_storage.rs
@@ -1,94 +1,248 @@
 //! storage backend for daemon
 //!
 
+use anyhow::Context;
+use common::PipeConfig;
 use serde::{Deserialize, Serialize};
-use sqlx::{sqlite::SqliteConnectOptions, ConnectOptions, Row, SqliteConnection};
-use std::str::FromStr;
+use sqlx::{sqlite::SqliteConnectOptions, ConnectOptions, Connection, Row, SqliteConnection};
+use std::path::Path;
+use tokio::sync::{
+    mpsc::{channel, Receiver, Sender},
+    oneshot::{channel as oneshot_channel, Sender as OneshotSender},
+};
 
-pub struct Storage {
-    #[allow(unused)]
-    path: String,
+pub struct DaemonStorage {
     connection: SqliteConnection,
-
-    config: Option<Config>,
 }
 
-#[derive(Serialize, Deserialize)]
-pub struct Config {
-    client_id: String,
-    client_secret: String,
+#[derive(Debug, Default)]
+pub struct Credentials {
+    pub client_id: String,
+    pub client_secret: String,
 }
 
-impl Storage {
-    pub async fn new(path: impl Into<String>) -> anyhow::Result<Self> {
-        let path = path.into();
-        let mut connection = SqliteConnectOptions::from_str(path.as_str())?
+#[derive(Debug, Default)]
+pub struct ServerInfo {
+    pub endpoint: String,
+    pub token: String,
+}
+
+#[derive(Debug, Default)]
+pub struct DaemonInfo {
+    pub display_name: String,
+    pub unique_id: String,
+}
+
+impl DaemonStorage {
+    pub async fn new(path: &Path) -> anyhow::Result<Self> {
+        let mut connection = SqliteConnectOptions::new()
+            .filename(path)
             .create_if_missing(true)
             .connect()
             .await?;
         sqlx::migrate!().run(&mut connection).await?;
-        Ok(Self {
-            path,
-            connection,
-            config: None,
-        })
+        tracing::info!("connected to {path:?}");
+        Ok(Self { connection })
     }
 
-    pub async fn write_config(&mut self, config: &Config) -> anyhow::Result<()> {
-        sqlx::query("INSERT INTO client_creds (client_id, client_secret) VALUES (?, ?)")
-            .bind(config.client_id.clone())
-            .bind(config.client_secret.clone())
+    pub async fn store_daemon_info(
+        &mut self,
+        display_name: &str,
+        unique_id: &str,
+    ) -> anyhow::Result<()> {
+        sqlx::query(
+            "INSERT INTO daemon VALUES ('display_name', ?), ('unique_id', ?) \
+            ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        )
+        .bind(display_name)
+        .bind(unique_id)
+        .execute(&mut self.connection)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn retrieve_daemon_info(&mut self) -> anyhow::Result<Option<DaemonInfo>> {
+        let reply = sqlx::query("SELECT key, value FROM daemon")
+            .fetch_all(&mut self.connection)
+            .await?
+            .into_iter()
+            .fold(None, |daemon_info, row| match row.get(0) {
+                "display_name" => Some(DaemonInfo {
+                    display_name: row.get(1),
+                    ..(daemon_info.unwrap_or_default())
+                }),
+                "unique_id" => Some(DaemonInfo {
+                    unique_id: row.get(1),
+                    ..(daemon_info.unwrap_or_default())
+                }),
+                key => {
+                    tracing::error!("bad daemon info key: {}", key);
+                    daemon_info
+                }
+            });
+        Ok(reply)
+    }
+
+    pub async fn store_http_credentials(
+        &mut self,
+        client_id: String,
+        client_secret: String,
+    ) -> anyhow::Result<()> {
+        sqlx::query(
+            "INSERT INTO connection VALUES ('client_id', ?), ('client_secret', ?) \
+            ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        )
+        .bind(client_id)
+        .bind(client_secret)
+        .execute(&mut self.connection)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn retrieve_http_credentials(&mut self) -> anyhow::Result<Option<Credentials>> {
+        let reply = sqlx::query(
+            "SELECT key, value FROM connection WHERE key in ('client_id', 'client_secret')",
+        )
+        .fetch_all(&mut self.connection)
+        .await?
+        .into_iter()
+        .fold(None, |credentials, row| match row.get(0) {
+            "client_id" => Some(Credentials {
+                client_id: row.get(1),
+                ..(credentials.unwrap_or_default())
+            }),
+            "client_secret" => Some(Credentials {
+                client_secret: row.get(1),
+                ..(credentials.unwrap_or_default())
+            }),
+            key => {
+                tracing::error!("bad credentials key: {}", key);
+                credentials
+            }
+        });
+        Ok(reply)
+    }
+
+    pub async fn store_server_info(&mut self, endpoint: &str, token: &str) -> anyhow::Result<()> {
+        sqlx::query(
+            "INSERT INTO connection VALUES ('endpoint', ?), ('token', ?) \
+            ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        )
+        .bind(endpoint)
+        .bind(token)
+        .execute(&mut self.connection)
+        .await?;
+        Ok(())
+    }
+
+    pub async fn retrieve_server_info(&mut self) -> anyhow::Result<Option<ServerInfo>> {
+        let reply =
+            sqlx::query("SELECT key, value FROM connection WHERE key in ('endpoint', 'token')")
+                .fetch_all(&mut self.connection)
+                .await?
+                .into_iter()
+                .fold(None, |server_info, row| match row.get(0) {
+                    "endpoint" => Some(ServerInfo {
+                        endpoint: row.get(1),
+                        ..(server_info.unwrap_or_default())
+                    }),
+                    "token" => Some(ServerInfo {
+                        token: row.get(1),
+                        ..(server_info.unwrap_or_default())
+                    }),
+                    key => {
+                        tracing::error!("bad server info key: {}", key);
+                        server_info
+                    }
+                });
+        Ok(reply)
+    }
+
+    // FIXME: common crate
+    // FIXME: there is a lot of garbage in pipe config
+    pub async fn store_pipes(&mut self, configs: &[PipeConfig]) -> anyhow::Result<()> {
+        let mut transaction = self.connection.begin().await?;
+        for config in configs {
+            sqlx::query("INSERT INTO pipe(id, config) VALUES(?, ?) ON CONFLICT DO UPDATE set config=excluded.config")
+                .bind(config.id as i64)
+                .bind(&serde_json::to_string(&config.pipe)?)
+                .execute(&mut *transaction)
+                .await?;
+        }
+        transaction.commit().await?;
+        Ok(())
+    }
+
+    pub async fn remove_pipe(&mut self, id: u64) -> anyhow::Result<()> {
+        sqlx::query("DELETE FROM pipe WHERE id=?")
+            .bind(id as i64)
             .execute(&mut self.connection)
             .await?;
         Ok(())
     }
 
-    pub async fn read_config(&mut self) -> anyhow::Result<Option<Config>> {
-        let row = sqlx::query("SELECT client_id, client_secret FROM client_creds")
-            .fetch_optional(&mut self.connection)
-            .await?;
-        match row {
-            Some(row) => {
-                let client_id: String = row.get(0);
-                let client_secret: String = row.get(1);
-                Ok(Some(Config {
-                    client_id,
-                    client_secret,
-                }))
-            }
-            None => Ok(None),
-        }
+    // FIXME: common crate
+    pub async fn retrieve_pipes(&mut self) -> anyhow::Result<Vec<PipeConfig>> {
+        let pipes = sqlx::query("SELECT id, config FROM pipe")
+            .fetch_all(&mut self.connection)
+            .await?
+            .into_iter()
+            .filter_map(|row| {
+                let id = row.get::<i64, _>(0) as u64;
+                let raw_config = row.get::<String, _>(1);
+                match serde_json::from_str(raw_config.as_str()) {
+                    // FIXME: workspace id is just irrelevant to pipe configuration and should be
+                    // stored separately, since it's metadata for UI
+                    Ok(pipe) => Some(PipeConfig{ id, pipe, workspace_id: 1}),
+                    Err(e) => {
+                        tracing::error!("failed to parse pipe configuration, pipe_id: {id}, raw_config: {raw_config}");
+                        None
+                    }
+                }
+            })
+            .collect();
+        Ok(pipes)
     }
 
-    pub async fn store_client_creds(
-        &mut self,
-        client_id: String,
-        client_secret: String,
-    ) -> anyhow::Result<()> {
-        self.write_config(&Config {
-            client_id,
-            client_secret,
-        })
-        .await?;
+    pub async fn store_config_hash(&mut self, hash: &str) -> anyhow::Result<()> {
+        sqlx::query(
+            "INSERT INTO config VALUES ('config_hash', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value"
+        )
+            .bind(hash)
+            .execute(&mut self.connection)
+            .await?;
         Ok(())
     }
 
-    pub async fn retrieve_client_creds(&mut self) -> anyhow::Result<Option<(String, String)>> {
-        // Try to load the config if it's not already loaded
-        if self.config.is_none() {
-            if let Ok(Some(c)) = self.read_config().await {
-                self.config = Some(c);
-            } else {
-                return Ok(None);
-            }
-        }
+    pub async fn retrieve_config_hash(&mut self) -> anyhow::Result<Option<String>> {
+        Ok(
+            sqlx::query("SELECT value FROM config WHERE key == 'config_hash'")
+                .fetch_optional(&mut self.connection)
+                .await?
+                .map(|row| row.get::<String, _>(0)),
+        )
+    }
 
-        // Assuming at this point self.config must be Some
-        let c = self.config.as_ref().unwrap();
-        Ok(Some((c.client_id.clone(), c.client_secret.clone())))
+    pub async fn retrieve_configs(&self) -> anyhow::Result<Vec<()>> {
+        Ok(vec![])
+    }
+
+    pub async fn reset_state(&mut self) -> anyhow::Result<()> {
+        let queries = &[
+            "DELETE FROM connections",
+            "DELETE FROM daemon",
+            "DELETE FROM config",
+            "DELETE FROM pipe",
+        ];
+        for query in queries {
+            sqlx::query(query).execute(&mut self.connection).await?;
+        }
+        Ok(())
     }
 }
 
-pub async fn new(storage_path: String) -> anyhow::Result<Storage> {
-    Storage::new(storage_path).await
+pub async fn new(storage_path: &Path) -> anyhow::Result<DaemonStorage> {
+    DaemonStorage::new(storage_path)
+        .await
+        .context("failed to initialized daemon storage")
 }

--- a/myceliald/src/main.rs
+++ b/myceliald/src/main.rs
@@ -1,19 +1,28 @@
-//! # Client
-//! - communicates with server, grabs and persists pipe configs:
-//!     - dumb server endpoint polling
-//!     - server dumbly returns all existing pipes
-//! - schedules and runs pipes
+#![allow(unused)]
+mod config_watcher;
 mod constructors;
 mod daemon_storage;
 mod http_client;
 mod runtime;
 mod storage;
 
+use anyhow::{anyhow, Context, Result};
 use clap::Parser;
 use common::ClientConfig;
-use std::fs::File;
-use std::io::Read;
-use anyhow::{anyhow, Context, Result};
+use common::PipeConfig;
+use config_watcher::ConfigWatcherHandle;
+use daemon_storage::{DaemonInfo, DaemonStorage, ServerInfo};
+use http_client::{HttpClientEvent, HttpClientHandle};
+use pipe::{config::Config, scheduler::SchedulerHandle};
+use sha2::Digest;
+use std::collections::HashSet;
+use std::env::current_dir;
+use std::path::Path;
+use std::path::PathBuf;
+use storage::SqliteStorageHandle;
+use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+
+use crate::config_watcher::ConfigWatcherEvent;
 
 #[derive(Parser)]
 struct Cli {
@@ -22,30 +31,293 @@ struct Cli {
     config: String,
 }
 
-fn read_config(path: &str) -> Result<ClientConfig> {
-    let mut config = String::new();
-    let mut config_file = File::open(path)
-        .context(format!("failed to open config file at '{path}'"))?;
-    config_file.read_to_string(&mut config)?;
+async fn read_config(path: &Path) -> Result<ClientConfig> {
+    let config = tokio::fs::read_to_string(path)
+        .await
+        .context(format!("failed to open config file at '{path:?}'"))?;
     Ok(toml::from_str(&config)?)
 }
 
-async fn run() -> Result<()> {
-    let cli = Cli::try_parse()?;
-    let config = read_config(&cli.config)?;
+struct Daemon {
+    config: ClientConfig,
+    config_path: PathBuf,
+    storage_path: PathBuf,
+    // FIXME: common crate
+    config_watcher_handle: ConfigWatcherHandle,
+    daemon_storage: DaemonStorage,
+    section_storage_handle: SqliteStorageHandle,
+    scheduler_handle: SchedulerHandle,
+    http_client_handle: HttpClientHandle,
+    rx: UnboundedReceiver<DaemonMessage>,
+}
 
-    let storage_handle = storage::new(config.node.storage_path.clone()).await?;
-    let runtime_handle = runtime::new(storage_handle.clone());
-    let daemon_storage = daemon_storage::new(config.node.storage_path.clone()).await?;
-    let client_handle = http_client::new(config, runtime_handle, daemon_storage);
-    client_handle.await?.map_err(|e| anyhow!(e))?;
-    Ok(())
+#[derive(Debug)]
+pub enum DaemonMessage {
+    ConfigWatcher(ConfigWatcherEvent),
+    HttpClient(HttpClientEvent),
+}
+
+#[derive(Debug)]
+enum Reset {
+    None,
+    // state reset - daemon storage and section storage are wiped
+    State,
+    // storage path was changed, restart all subsystems with updated path
+    Restart,
+}
+
+impl Daemon {
+    async fn new(cli: Cli) -> Result<Self> {
+        let mut config_path = PathBuf::from(cli.config);
+        if !config_path.is_absolute() {
+            config_path = current_dir()?.join(config_path)
+        }
+        let (tx, rx) = unbounded_channel();
+        let config = read_config(config_path.as_path()).await?;
+        let mut storage_path = PathBuf::from(&config.node.storage_path);
+        if !storage_path.is_absolute() {
+            storage_path = current_dir()?.join(storage_path);
+        }
+        let daemon_storage = daemon_storage::new(storage_path.as_path()).await?;
+        let section_storage_handle = storage::new(storage_path.as_path()).await?;
+        let scheduler_handle = runtime::new(section_storage_handle.clone());
+        let config_watcher_handle = config_watcher::new(config_path.as_path(), tx.clone());
+        let http_client_handle = http_client::new(tx);
+        Ok(Self {
+            config,
+            config_path,
+            storage_path,
+            config_watcher_handle,
+            daemon_storage,
+            section_storage_handle,
+            scheduler_handle,
+            http_client_handle,
+            rx,
+        })
+    }
+
+    async fn run(&mut self) -> Result<Reset> {
+        if let reset @ (Reset::State | Reset::Restart) = self.maybe_reset_state().await? {
+            self.shutdown().await.ok();
+            return Ok(reset);
+        }
+
+        self.setup_http_client().await?;
+        self.maybe_resubmit_sections().await?;
+        self.reschedule_pipes().await?;
+
+        while let Some(message) = self.rx.recv().await {
+            match message {
+                DaemonMessage::ConfigWatcher(ConfigWatcherEvent::Modified) => {
+                    match read_config(&self.config_path).await {
+                        Ok(config) => self.config = config,
+                        Err(e) => {
+                            tracing::error!("failed to read config: {e:?}");
+                            continue;
+                        }
+                    };
+                    match self.maybe_reset_state().await? {
+                        Reset::None => {
+                            self.maybe_resubmit_sections().await?;
+                        }
+                        reset @ (Reset::State | Reset::Restart) => {
+                            self.shutdown().await.ok();
+                            return Ok(reset);
+                        }
+                    }
+                }
+                DaemonMessage::HttpClient(HttpClientEvent::Configs { configs }) => {
+                    tracing::debug!("got new configs: {configs:?}");
+                    self.daemon_storage.store_pipes(configs.as_slice()).await?;
+                    self.reschedule_pipes().await?;
+                }
+                DaemonMessage::HttpClient(HttpClientEvent::Credentials {
+                    client_id,
+                    client_secret,
+                }) => {
+                    // client was able to 'exchange' auth token for credentials
+                    self.daemon_storage
+                        .store_http_credentials(client_id, client_secret)
+                        .await?;
+                }
+                DaemonMessage::HttpClient(HttpClientEvent::SectionsSubmitted { config_hash }) => {
+                    self.daemon_storage
+                        .store_config_hash(config_hash.as_str())
+                        .await?;
+                }
+            }
+        }
+        Ok(Reset::None)
+    }
+
+    // set credentials to http client
+    async fn setup_http_client(&mut self) -> anyhow::Result<()> {
+        let server_info = self.daemon_storage.retrieve_server_info().await?;
+        let daemon_info = self.daemon_storage.retrieve_daemon_info().await?;
+        let http_credentials = self.daemon_storage.retrieve_http_credentials().await?;
+        match (&server_info, &daemon_info, &http_credentials) {
+            (Some(ServerInfo{ endpoint, token }), Some(DaemonInfo{ unique_id, display_name }), creds) => {
+                let (client_id, client_secret) = creds
+                    .as_ref()
+                    .map(|creds| (Some(creds.client_id.as_str()), Some(creds.client_secret.as_str())))
+                    .unwrap_or((None, None));
+                self.http_client_handle.set_connection(
+                    endpoint, token, unique_id, display_name, client_id, client_secret
+                ).await?;
+            },
+            (None, _, _) =>
+                tracing::error!("server info is missing, http client can't poll configs without endpoint/token"),
+            (_, None, _) =>
+                tracing::error!("daemon info is missing, http client can't submit sections without display_name/unique_id"),
+        };
+        Ok(())
+    }
+
+    // check if sections need to be submitted to control plane
+    async fn maybe_resubmit_sections(&mut self) -> anyhow::Result<()> {
+        let stored_config_hash = self.daemon_storage.retrieve_config_hash().await?;
+
+        // serialize current configuration
+        let config_hash = format!("{:x}", sha2::Sha256::digest(toml::to_string(&self.config)?));
+        match stored_config_hash {
+            Some(hash) if config_hash == hash => (),
+            _ => {
+                let sources = self.config.sources.clone();
+                let destinations = self.config.destinations.clone();
+                self.http_client_handle
+                    .submit_sections(config_hash, sources, destinations)
+                    .await?;
+            }
+        };
+        Ok(())
+    }
+
+    //
+    async fn reschedule_pipes(&mut self) -> anyhow::Result<()> {
+        let mut started = HashSet::new();
+        for pipe in self.daemon_storage.retrieve_pipes().await? {
+            let id = pipe.id;
+            match pipe.try_into() {
+                Ok(conf) => {
+                    self.scheduler_handle
+                        .add_pipe(id, conf)
+                        .await
+                        .map_err(|e| anyhow!(e))?;
+                    started.insert(id);
+                }
+                Err(e) => {
+                    tracing::error!("failed to convert pipe config into scheduler config: {e}");
+                }
+            }
+        }
+        let mut scheduled = HashSet::from_iter(
+            self.scheduler_handle
+                .list_ids()
+                .await
+                .map_err(|e| anyhow!(e))?
+                .into_iter(),
+        );
+        for id in scheduled.difference(&started) {
+            self.scheduler_handle
+                .remove_pipe(*id)
+                .await
+                .map_err(|e| anyhow!(e))?;
+        }
+        Ok(())
+    }
+
+    // check if daemon needs reset/restart
+    // - change in endpoint/token force state reset and restart
+    // - change in unique_id/display_name force state reset and restart
+    // - change to storage path force restart
+    async fn maybe_reset_state(&mut self) -> Result<Reset> {
+        let conf_storage_path = PathBuf::from(&self.config.node.storage_path);
+        let conf_storage_path = current_dir()?.join(conf_storage_path);
+        let conf_display_name = &self.config.node.display_name;
+        let conf_unique_id = &self.config.node.unique_id;
+        let conf_endpoint = &self.config.server.endpoint;
+        let conf_token = &self.config.node.auth_token;
+
+        let daemon_info = self.daemon_storage.retrieve_daemon_info().await?;
+        let server_info = self.daemon_storage.retrieve_server_info().await?;
+        let reset_type = match (self.storage_path.as_path(), daemon_info, server_info) {
+            (path, _, _) if path != conf_storage_path => Reset::Restart,
+            (
+                _,
+                Some(DaemonInfo {
+                    ref display_name,
+                    ref unique_id,
+                }),
+                _,
+            ) if display_name != conf_display_name || unique_id != conf_unique_id => Reset::State,
+            (
+                _,
+                _,
+                Some(ServerInfo {
+                    ref endpoint,
+                    ref token,
+                }),
+            ) if endpoint != conf_endpoint || token != conf_token => Reset::State,
+            (_, server_info, daemon_info) if server_info.is_none() || daemon_info.is_none() => {
+                self.daemon_storage
+                    .store_daemon_info(conf_display_name, conf_unique_id)
+                    .await?;
+                self.daemon_storage
+                    .store_server_info(conf_endpoint, conf_token)
+                    .await?;
+                Reset::None
+            }
+            _ => Reset::None,
+        };
+        if let Reset::State = reset_type {
+            tracing::info!("resetting state");
+            self.daemon_storage.reset_state().await?;
+            self.section_storage_handle
+                .reset_state()
+                .await
+                .map_err(|e| anyhow!(e))?;
+            for id in self
+                .scheduler_handle
+                .list_ids()
+                .await
+                .map_err(|e| anyhow!(e))?
+            {
+                self.scheduler_handle
+                    .remove_pipe(id)
+                    .await
+                    .map_err(|e| anyhow!(e))?;
+            }
+        };
+        Ok(reset_type)
+    }
+
+    async fn shutdown(&mut self) -> anyhow::Result<()> {
+        self.http_client_handle.shutdown().await.ok();
+        self.scheduler_handle.shutdown().await.ok();
+        self.section_storage_handle.shutdown().await.ok();
+        self.config_watcher_handle.shutdown().await.ok();
+        Ok(())
+    }
 }
 
 #[tokio::main]
-async fn main() {
+async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
-    if let Err(e) = run().await {
-        tracing::error!("{}", e);
+    loop {
+        let mut daemon = Daemon::new(Cli::try_parse()?)
+            .await
+            .context("failed to initialize application")?;
+        match daemon.run().await {
+            Ok(Reset::State) => {
+                tracing::info!("daemon state was reset, restarting subsystems");
+                continue;
+            }
+            Ok(Reset::Restart) => {
+                tracing::info!("daemon restarting subsystems");
+                continue;
+            }
+            Err(e) => return Err(e),
+            _ => return Ok(()),
+        }
     }
 }

--- a/pipe/runtime/src/scheduler.rs
+++ b/pipe/runtime/src/scheduler.rs
@@ -331,7 +331,7 @@ impl SchedulerHandle {
     }
 
     /// Shutdown scheduler
-    pub async fn shutdown(self) -> Result<(), SectionError> {
+    pub async fn shutdown(&self) -> Result<(), SectionError> {
         call!(self, Message::Shutdown {})
     }
 

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -25,13 +25,13 @@ serde = { version = "1", features = ["derive"] }
 tokio-util = "0.7.8"
 sqlx = { version = "0.7", features = ["runtime-tokio", "chrono", "postgres", "tls-rustls"]}
 tower-http = { version = "0.4.1", features = ["fs"] }
-log = "0.4"
-pretty_env_logger = "0.5"
 common = { path = "../common" }
 rust-embed = "8.0.0"
 mime_guess = { version = "2" }
 async-stream = "0.3.5"
 bcrypt = "0.15.0"
+tracing = "0.1.40"
+tracing-subscriber = "0.3.18"
 
 [dependencies.uuid]
 version = "1.4.0"

--- a/server/src/daemon_basic_auth.rs
+++ b/server/src/daemon_basic_auth.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use axum::{extract::State, response::IntoResponse, Extension, Json};
-use common::{Destination, ProvisionDaemonRequest, ProvisionDaemonResponse};
-use serde::Deserialize;
+use common::{ProvisionDaemonRequest, ProvisionDaemonResponse};
+
 use uuid::Uuid;
 
 use crate::{error, App, UserID};
@@ -35,31 +35,4 @@ pub async fn provision_daemon(
                 client_secret,
             })
         })
-}
-
-// FIXME: common crate
-#[derive(Debug, Deserialize)]
-pub struct Submit {
-    // FIXME:
-    unique_id: String,
-    sources: Vec<common::Source>,
-    destinations: Vec<common::Destination>,
-}
-
-// FIXME: common crate
-pub async fn submit_sections(
-    State(state): State<Arc<App>>,
-    Extension(UserID(user_id)): Extension<UserID>,
-    Json(payload): Json<Submit>,
-) -> Result<impl IntoResponse, error::Error> {
-    state
-        .database
-        .submit_sections(
-            payload.unique_id.as_str(),
-            user_id.as_str(),
-            &serde_json::to_string(payload.sources.as_slice())?,
-            &serde_json::to_string(payload.destinations.as_slice())?,
-        )
-        .await?;
-    Ok("")
 }

--- a/server/src/daemon_basic_auth.rs
+++ b/server/src/daemon_basic_auth.rs
@@ -1,39 +1,65 @@
 use std::sync::Arc;
 
 use axum::{extract::State, response::IntoResponse, Extension, Json};
-use common::{ProvisionClientRequest, ProvisionClientResponse};
+use common::{Destination, ProvisionDaemonRequest, ProvisionDaemonResponse};
+use serde::Deserialize;
 use uuid::Uuid;
 
 use crate::{error, App, UserID};
 
-pub async fn provision_client(
+// FIXME: redo provisioning workflow
+pub async fn provision_daemon(
     State(state): State<Arc<App>>,
-    Extension(user_id): Extension<UserID>,
-    Json(payload): Json<ProvisionClientRequest>,
+    Extension(UserID(user_id)): Extension<UserID>,
+    Json(payload): Json<ProvisionDaemonRequest>,
 ) -> Result<impl IntoResponse, error::Error> {
-    let client_id = payload.client_config.node.unique_id;
+    let unique_id = payload.unique_id;
+    let display_name = payload.display_name;
     let unique_client_id = Uuid::new_v4().to_string();
     let client_secret = Uuid::new_v4().to_string();
     let client_secret_hash = bcrypt::hash(client_secret.clone(), 12).unwrap();
 
     state
         .database
-        .insert_client(
-            // add the user_id here.
-            &client_id,
-            user_id.0.as_str(),
-            &payload.client_config.node.display_name,
-            &payload.client_config.sources,
-            &payload.client_config.destinations,
-            unique_client_id.as_str(),
-            client_secret_hash.as_str(),
+        .provision_daemon(
+            &unique_id,
+            &user_id,
+            &display_name,
+            &unique_client_id,
+            &client_secret_hash,
         )
         .await
         .map(|_| {
-            Json(ProvisionClientResponse {
-                id: client_id.clone(),
+            Json(ProvisionDaemonResponse {
                 client_id: unique_client_id,
                 client_secret,
             })
         })
+}
+
+// FIXME: common crate
+#[derive(Debug, Deserialize)]
+pub struct Submit {
+    // FIXME:
+    unique_id: String,
+    sources: Vec<common::Source>,
+    destinations: Vec<common::Destination>,
+}
+
+// FIXME: common crate
+pub async fn submit_sections(
+    State(state): State<Arc<App>>,
+    Extension(UserID(user_id)): Extension<UserID>,
+    Json(payload): Json<Submit>,
+) -> Result<impl IntoResponse, error::Error> {
+    state
+        .database
+        .submit_sections(
+            payload.unique_id.as_str(),
+            user_id.as_str(),
+            &serde_json::to_string(payload.sources.as_slice())?,
+            &serde_json::to_string(payload.destinations.as_slice())?,
+        )
+        .await?;
+    Ok("")
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,11 +1,10 @@
 use axum::{
     extract::State,
-    headers::{authorization::Basic, Authorization},
     http::{self, header, Method, Request, StatusCode, Uri},
     middleware::{self, Next},
     response::{IntoResponse, Response},
     routing::{get, post},
-    Extension, Json, Router, Server, TypedHeader,
+    Extension, Json, Router, Server,
 };
 use base64::engine::{general_purpose::STANDARD as BASE64, Engine};
 use chrono::NaiveDateTime;
@@ -16,7 +15,7 @@ use futures::{Stream, StreamExt};
 use jsonwebtoken::{decode, jwk, DecodingKey, Validation};
 use rust_embed::RustEmbed;
 use serde::{Deserialize, Serialize};
-use serde_json::json;
+
 use sqlx::{
     pool::Pool,
     postgres::{PgPoolOptions, PgRow, Postgres},

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -279,11 +279,11 @@ impl Database {
             "INSERT INTO clients (id, user_id, display_name, sources, destinations, unique_client_id, client_secret_hash) \
             VALUES ($1, $2, $3, '[]', '[]', $4, $5) \
             ON CONFLICT (id) DO UPDATE SET \
-            display_name = $3, \
-            sources = $4, \
-            destinations = $5, \
-            unique_client_id = $6, \
-            client_secret_hash = $7"
+            display_name=excluded.display_name, \
+            sources=excluded.sources, \
+            destinations=excluded.destinations, \
+            unique_client_id=excluded.unique_client_id, \
+            client_secret_hash=excluded.client_secret_hash"
         )
             .bind(unique_id)
             .bind(user_id)

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -27,7 +27,6 @@ use std::pin::Pin;
 use std::sync::Arc;
 
 use app::App;
-
 mod app;
 mod daemon_auth;
 mod daemon_basic_auth;
@@ -221,7 +220,6 @@ async fn get_clients(
 async fn log_middleware<B>(
     method: Method,
     uri: Uri,
-    maybe_auth: Option<TypedHeader<Authorization<Basic>>>,
     request: Request<B>,
     next: Next<B>,
 ) -> Response {
@@ -231,23 +229,14 @@ async fn log_middleware<B>(
         .signed_duration_since(timestamp)
         .num_milliseconds();
 
-    let token = match maybe_auth.as_ref() {
-        None => "",
-        Some(TypedHeader(Authorization(basic))) => basic.username(),
-    };
-
     let error: Option<&error::Error> = response.extensions().get();
-    // FIXME: do not log token
-    let log = json!({
-        "token": token,
-        "timestamp": timestamp,
-        "request_time_ms": request_time_ms,
-        "method": method.as_str(),
-        "status_code": response.status().as_u16(),
-        "path": uri.path(),
-        "error": error.map(|e| format!("{:?}", e)),
-    });
-    log::info!("{}", log);
+    tracing::info!(
+        request_time_ms = request_time_ms,
+        method = method.as_str(),
+        status_code = response.status().as_u16(),
+        path = uri.path(),
+        error = error.map(|e| format!("{:?}", e)),
+    );
     response
 }
 
@@ -278,27 +267,46 @@ impl Database {
     }
 
     #[allow(clippy::too_many_arguments)]
-    async fn insert_client(
+    async fn provision_daemon(
         &self,
-        client_id: &str,
+        unique_id: &str,
         user_id: &str,
         display_name: &str,
-        sources: &[Source],
-        destinations: &[Destination],
         unique_client_id: &str,
         client_secret_hash: &str,
     ) -> Result<(), error::Error> {
-        let sources = serde_json::to_string(sources)?;
-        let destinations = serde_json::to_string(destinations)?;
-
-        let _ = sqlx::query("INSERT INTO clients (id, user_id, display_name, sources, destinations, unique_client_id, client_secret_hash) VALUES ($1, $2, $3, $4, $5, $6, $7) ON CONFLICT (id) DO UPDATE SET display_name = $3, sources = $4, destinations = $5, unique_client_id = $6, client_secret_hash = $7")
-            .bind(client_id)
+        sqlx::query(
+            "INSERT INTO clients (id, user_id, display_name, sources, destinations, unique_client_id, client_secret_hash) \
+            VALUES ($1, $2, $3, '[]', '[]', $4, $5) \
+            ON CONFLICT (id) DO UPDATE SET \
+            display_name = $3, \
+            sources = $4, \
+            destinations = $5, \
+            unique_client_id = $6, \
+            client_secret_hash = $7"
+        )
+            .bind(unique_id)
             .bind(user_id)
             .bind(display_name)
-            .bind(sources)
-            .bind(destinations)
             .bind(unique_client_id)
             .bind(client_secret_hash)
+            .execute(&*self.connection)
+            .await?;
+        Ok(())
+    }
+
+    async fn submit_sections(
+        &self,
+        unique_id: &str,
+        user_id: &str,
+        sources: &str,
+        destinations: &str,
+    ) -> Result<(), error::Error> {
+        sqlx::query("UPDATE clients SET sources=$1, destinations=$2 WHERE id=$3 AND user_id=$4")
+            .bind(sources)
+            .bind(destinations)
+            .bind(unique_id)
+            .bind(user_id)
             .execute(&*self.connection)
             .await?;
         Ok(())
@@ -600,7 +608,7 @@ pub struct Auth0Audience(String);
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    pretty_env_logger::init();
+    tracing_subscriber::fmt::init();
 
     let cli = Cli::try_parse()?;
     let app = App::new(cli.database_path).await?;
@@ -648,7 +656,10 @@ async fn main() -> anyhow::Result<()> {
     }
 
     let daemon_basic_api = Router::new()
-        .route("/api/client", post(daemon_basic_auth::provision_client))
+        .route(
+            "/api/daemon/provision",
+            post(daemon_basic_auth::provision_daemon),
+        )
         .layer(middleware::from_fn_with_state(
             state.clone(),
             validate_client_basic_auth,
@@ -657,6 +668,10 @@ async fn main() -> anyhow::Result<()> {
     // daemon uses its client_id and client_secret to auth, regardless of whether user auth is turned on
     let daemon_protected_api = Router::new()
         .route("/api/pipe", get(daemon_auth::get_pipe_configs))
+        .route(
+            "/api/daemon/submit_sections",
+            post(daemon_auth::submit_sections),
+        )
         .layer(middleware::from_fn_with_state(
             state.clone(),
             daemon_auth::daemon_auth,

--- a/server/src/pipe.rs
+++ b/server/src/pipe.rs
@@ -10,7 +10,7 @@ pub async fn post_config(
     Extension(user_id): Extension<UserID>,
     Json(configs): Json<PipeConfigs>,
 ) -> Result<impl IntoResponse, error::Error> {
-    log::trace!("Configs in: {:?}", &configs);
+    tracing::trace!("Configs in: {:?}", &configs);
     app.validate_configs(&configs)?;
     let ids = app.set_configs(&configs, user_id.0.as_str()).await?;
     Ok(Json(


### PR DESCRIPTION
  - Added config watcher, daemon is able to do different kind of resets, depending on config change - from simple section resubmissions to full resets & subsystems restart
  - Daemon app in main module is now responsible for all main business logic.
  - Daemon now persists pipe configs and able to drive some work even if server is not available.
  - Redo initial registration between daemon and server. No longer daemon throws whole config towards server direction.
  - Substitute thiserror with anyhow, since myceliald is binary, not library
  - Use tracing instead of logging.