### PR TITLE
make vec length match column length

### DIFF
--- a/pipe/section/section_impls/tagging_transformer/src/lib.rs
+++ b/pipe/section/section_impls/tagging_transformer/src/lib.rs
@@ -85,7 +85,7 @@ where
                                                 .iter()
                                                 .map(std::borrow::ToOwned::to_owned)
                                                 .collect::<Vec<_>>();
-                                            let tag = Arc::new(StringArray::from(vec![self.text.clone()]));
+                                            let tag = Arc::new(StringArray::from(vec![self.text.clone(); values[0].len()]));
                                             values.push(tag);
 
                                             // create a new arrow RecordBatch from the schema and columns


### PR DESCRIPTION
To fix `InvalidArgumentError("all columns in a record batch must have the same length")`