### PR TITLE
Adds dir section

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -92,3 +92,4 @@ jobs:
           cargo test --target ${{ matrix.target }}
           cargo test --release --target ${{ matrix.target }}
 
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,3 +152,4 @@ jobs:
           artifactErrorsFailBuild: true
           allowUpdates: true
 
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a116f46a969224200a0a97f29cfd4c50e7534e4b4826bd23ea2c3c533039c82c"
+checksum = "86a9249d1447a85f95810c620abea82e001fe58a31713fcce614caf52499f905"
 dependencies = [
  "flate2",
  "futures-core",
@@ -616,18 +616,18 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.78"
+version = "0.1.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
+checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -641,15 +641,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
 
 [[package]]
 name = "axum"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1236b4b292f6c4d6dc34604bb5120d85c3fe1d1aa596bd5cc52ca054d13e7b9e"
+checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -671,7 +671,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.0",
  "tokio",
  "tower",
  "tower-layer",
@@ -694,7 +694,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -702,9 +702,9 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "895ff42f72016617773af68fb90da2a9677d89c62338ec09162d4909d86fdd8f"
+checksum = "0be6ea09c9b96cb5076af0de2e383bd2bc0c18f827cf1967bdd353e0b910d733"
 dependencies = [
  "axum",
  "axum-core",
@@ -720,13 +720,14 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "26b05800d2e817c8b3b4b54abd461726265fa9789ae34330622f2db9ee696f9d"
 dependencies = [
  "addr2line",
  "cc",
@@ -822,9 +823,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58b559fd6448c6e2fd0adb5720cd98a2506594cafa4737ff98c396f3e82f667"
+checksum = "0901fc8eb0aca4c83be0106d6f2db17d86a08dfc2c25f0e84464bf381158add6"
 dependencies = [
  "borsh-derive",
  "cfg_aliases",
@@ -832,15 +833,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aadb5b6ccbd078890f6d7003694e33816e6b784358f18e15e7e6d9f065a57cd"
+checksum = "51670c3aa053938b0ee3bd67c3817e471e626151131b934038e83c5bf8de48f5"
 dependencies = [
  "once_cell",
  "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
  "syn_derive",
 ]
 
@@ -911,9 +912,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "calamine"
@@ -956,9 +957,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
-version = "0.4.35"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf5903dcbc0a39312feb77df2ff4c76387d591b9fc7b04a238dcf8bb62639a"
+checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -981,9 +982,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.3"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "949626d00e063efc93b6dca932419ceb5432f99769911c0b995f7e884c778813"
+checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -1003,14 +1004,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.3"
+version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
+checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1202,9 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fffa369a668c8af7dbf8b5e56c9f744fbd399949ed171606040001947de40b1c"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -1230,6 +1231,21 @@ dependencies = [
  "const-oid",
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "dir"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "notify",
+ "regex",
+ "section",
+ "stub",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1325,9 +1341,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.0.1"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+checksum = "658bd65b1cf4c852a3cc96f18a8ce7b5640f6b703f905c7d74532294c2a63984"
 
 [[package]]
 name = "file"
@@ -1509,7 +1525,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1592,9 +1608,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -1602,25 +1618,6 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51ee2dd2e4f378392eeff5d51618cd9a63166a2513846bbc55f21cfacd9199d4"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 1.1.0",
  "indexmap",
  "slab",
  "tokio",
@@ -1846,7 +1843,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.25",
+ "h2",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -1869,7 +1866,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.3",
  "http 1.1.0",
  "http-body 1.0.0",
  "httparse",
@@ -1958,9 +1954,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b0b929d511467233429c45a44ac1dcaa21ba0f5ba11e4879e6ed28ddb4f9df4"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
@@ -1974,7 +1970,7 @@ checksum = "0122b7114117e64a63ac49f752a5ca4624d534c7b1c7de796ac196381cd2d947"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2041,9 +2037,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
@@ -2079,9 +2075,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.2.0"
+version = "9.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7ea04a7c5c055c175f189b6dc6ba036fd62306b58c66c9f6389036c503a3f4"
+checksum = "b9ae10193d25051e74945f1ea2d0b42e03cc3b890f7e4cc5faa44997d808193f"
 dependencies = [
  "base64 0.21.7",
  "js-sys",
@@ -2223,9 +2219,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.15"
+version = "1.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037731f5d3aaa87a5675e895b63ddff1a87624bc29f77004ea829809654e48f6"
+checksum = "5e143b5e666b2695d28f6bca6497720813f699c9602dd7f5cac91008b8ada7f9"
 dependencies = [
  "cc",
  "libc",
@@ -2257,9 +2253,9 @@ checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "912b45c753ff5f7f5208307e8ace7d2a2e30d024e26d3509f3dce546c044ce15"
+checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
 dependencies = [
  "twox-hash",
 ]
@@ -2282,9 +2278,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "mime"
@@ -2350,6 +2346,7 @@ dependencies = [
  "base64 0.21.7",
  "clap",
  "common",
+ "dir",
  "excel_connector",
  "file",
  "hello_world",
@@ -2658,7 +2655,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2669,9 +2666,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.101"
+version = "0.9.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
+checksum = "c597637d56fbc83893a35eb0dd04b2b8e7a50c91e64e9493e398b5df4fb45fa2"
 dependencies = [
  "cc",
  "libc",
@@ -2833,14 +2830,14 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "pin-utils"
@@ -3096,9 +3093,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.3"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3119,9 +3116,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rend"
@@ -3144,7 +3141,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.25",
+ "h2",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
@@ -3165,7 +3162,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -3343,7 +3340,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.53",
+ "syn 2.0.58",
  "walkdir",
 ]
 
@@ -3359,9 +3356,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.34.3"
+version = "1.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39449a79f45e8da28c57c341891b69a183044b29518bb8f86dbac9df60bb7df"
+checksum = "1790d1c4c0ca81211399e0e0af16333276f375209e71a37b67698a373db5b47a"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -3527,7 +3524,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
  "thiserror",
 ]
 
@@ -3550,9 +3547,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.9.2"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b64fb303737d99b81884b2c63433e9ae28abebe5eb5045dcdd175dc2ecf4de"
+checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation",
@@ -3563,9 +3560,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.9.1"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e932934257d3b408ed8f30db49d85ea163bfe74961f017f405b025af298f0c7a"
+checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3600,14 +3597,14 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
 dependencies = [
  "itoa",
  "ryu",
@@ -3659,7 +3656,7 @@ dependencies = [
  "clap",
  "common",
  "futures",
- "jsonwebtoken 9.2.0",
+ "jsonwebtoken 9.3.0",
  "mime_guess",
  "reqwest",
  "rust-embed",
@@ -3756,9 +3753,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "snafu"
@@ -4133,9 +4130,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.11.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
@@ -4153,7 +4150,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -4183,9 +4180,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.53"
+version = "2.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
+checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4201,7 +4198,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -4209,6 +4206,12 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384595c11a4e2969895cad5a8c4029115f5ab956a9e5ef4de79d11a426e5f20c"
 
 [[package]]
 name = "system-configuration"
@@ -4284,7 +4287,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -4365,9 +4368,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.36.0"
+version = "1.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61285f6515fa018fb2d1e46eb21223fff441ee8db5d0f1435e8ab4f5cdb80931"
+checksum = "1adbebffeca75fcfd058afa480fb6c0b81e165a0323f9c9d39c9697e37c46787"
 dependencies = [
  "backtrace",
  "bytes",
@@ -4390,7 +4393,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -4556,7 +4559,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -4727,7 +4730,7 @@ checksum = "9881bea7cbe687e36c9ab3b778c36cd0487402e270304e8b1296d5085303c1a2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -4800,7 +4803,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
  "wasm-bindgen-shared",
 ]
 
@@ -4834,7 +4837,7 @@ checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5116,7 +5119,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.53",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -5139,27 +5142,27 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bffb3309596d527cfcba7dfc6ed6052f1d39dfbd7c867aa2e865e4a449c10110"
+checksum = "2d789b1514203a1120ad2429eae43a7bd32b90976a7bb8a05f7ec02fa88cc23a"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "7.0.0"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43747c7422e2924c11144d5229878b98180ef8b06cca4ab5af37afc8a8d8ea3e"
+checksum = "1cd99b45c6bc03a018c8b8a86025678c87e55526064e38f9df301989dce7ec0a"
 dependencies = [
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.9+zstd.1.5.5"
+version = "2.0.10+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
+checksum = "c253a4914af5bafc8fa8c86ee400827e83cf6ec01195ec1f1ed8441bf00d65aa"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,6 @@ members = [
     "pipe/section/section_impls/tagging_transformer",
     "pipe/section/section_impls/mysql_connector",
     "pipe/section/section_impls/file",
+    "pipe/section/section_impls/dir",
 ]
 resolver = "2"

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -54,6 +54,7 @@ pub enum Source {
     Typecast_Transformer(TypecastTransformerConfig),
     Mysql_Connector(MysqlConnectorSourceConfig),
     File(FileSourceConfig),
+    Dir(DirSourceConfig),
 }
 
 /// Internally-tagged type of a source needs to match the variant name
@@ -229,6 +230,16 @@ pub struct FileSourceConfig {
     #[serde(flatten)]
     pub common_attrs: CommonAttrs,
     pub path: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct DirSourceConfig {
+    #[serde(flatten)]
+    pub common_attrs: CommonAttrs,
+    pub path: String,
+    pub pattern: Option<String>,
+    pub start_after: Option<String>,
+    pub interval: u64,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -237,7 +237,9 @@ pub struct DirSourceConfig {
     #[serde(flatten)]
     pub common_attrs: CommonAttrs,
     pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub pattern: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub start_after: Option<String>,
     pub interval: u64,
 }

--- a/myceliald/Cargo.toml
+++ b/myceliald/Cargo.toml
@@ -32,6 +32,7 @@ tagging_transformer = { path = "../pipe/section/section_impls/tagging_transforme
 typecast_transformer = { path = "../pipe/section/section_impls/typecast_transformer" }
 mysql_connector = { path = "../pipe/section/section_impls/mysql_connector/" }
 file = { path = "../pipe/section/section_impls/file/" }
+dir = { path = "../pipe/section/section_impls/dir/" }
 tracing = "0.1.40"
 tracing-subscriber = "0.3.18"
 notify = { version = "6.1.1", features = ["macos_kqueue"] }

--- a/myceliald/Makefile
+++ b/myceliald/Makefile
@@ -20,7 +20,7 @@ clean:
 
 .PHONY: dev
 dev:
-	RUST_LOG=$(RUST_LOG) cargo-watch \
+	cargo-watch \
 		--why \
 		-i client.db \
 		-i client.db-journal \

--- a/myceliald/config.example.toml
+++ b/myceliald/config.example.toml
@@ -84,6 +84,13 @@ display_name = "file source"
 path = "Cargo.toml"
 interval = 5
 
+[[sources]]
+type = "dir"
+display_name = "directory"
+path = ""
+start_after = ""
+interval = 5
+
 
 # DESTINATIONS
 # Define all data DESTINATIONS (data stores and directory paths)

--- a/myceliald/config.example.toml
+++ b/myceliald/config.example.toml
@@ -82,6 +82,7 @@ poll_interval = 5
 type = "file"
 display_name = "file source"
 path = "Cargo.toml"
+interval = 5
 
 
 # DESTINATIONS

--- a/myceliald/src/constructors/dir.rs
+++ b/myceliald/src/constructors/dir.rs
@@ -67,6 +67,7 @@ mod test {
         let source_config = DirSourceConfig::default();
         let mut c: HashMap<String, Value> =
             serde_json::from_str(&serde_json::to_string(&source_config).unwrap()).unwrap();
+        println!("c: {c:?}");
 
         let config: Map = c.drain().map(|(k, v)| (k, v.try_into().unwrap())).collect();
 

--- a/myceliald/src/constructors/dir.rs
+++ b/myceliald/src/constructors/dir.rs
@@ -1,0 +1,75 @@
+use std::time::Duration;
+
+use pipe::{
+    config::{Map, Value},
+    types::DynSection,
+};
+use section::{command_channel::SectionChannel, SectionError};
+
+pub fn source_ctor<S: SectionChannel>(
+    config: &Map,
+) -> Result<Box<dyn DynSection<S>>, SectionError> {
+    let path = config
+        .get("path")
+        .ok_or("dir section requires 'path'")?
+        .as_str()
+        .ok_or("'tables' should be string")?;
+    let pattern = match config.get("pattern") {
+        Some(Value::String(s)) => {
+            if s.is_empty() {
+                None
+            } else {
+                Some(s.clone())
+            }
+        }
+        Some(_other) => Err("pattern should be string")?,
+        None => None,
+    };
+    let start_after = match config.get("start_after") {
+        Some(Value::String(s)) => {
+            if s.is_empty() {
+                None
+            } else {
+                Some(s.clone())
+            }
+        }
+        Some(_) => Err("pattern should be string")?,
+        None => None,
+    };
+    let interval = match config
+        .get("interval")
+        .ok_or("dir source requires interval")?
+    {
+        Value::String(v) => v.parse()?,
+        Value::Int(i) => (*i) as _,
+        _ => Err("poll_interval should be integer")?,
+    };
+    Ok(Box::new(dir::source::DirSource::new(
+        path.into(),
+        pattern,
+        start_after,
+        Duration::from_secs(interval),
+    )?))
+}
+
+#[cfg(test)]
+mod test {
+    use std::collections::HashMap;
+
+    use common::DirSourceConfig;
+    use section::dummy::DummySectionChannel;
+    use serde_json::Value;
+
+    use super::*;
+
+    #[test]
+    fn test_source_ctor_matches_config() {
+        let source_config = DirSourceConfig::default();
+        let mut c: HashMap<String, Value> =
+            serde_json::from_str(&serde_json::to_string(&source_config).unwrap()).unwrap();
+
+        let config: Map = c.drain().map(|(k, v)| (k, v.try_into().unwrap())).collect();
+
+        assert!(source_ctor::<DummySectionChannel>(&config).is_ok());
+    }
+}

--- a/myceliald/src/constructors/mod.rs
+++ b/myceliald/src/constructors/mod.rs
@@ -1,3 +1,4 @@
+pub mod dir;
 pub mod excel_connector;
 pub mod file;
 pub mod hello_world;

--- a/myceliald/src/runtime.rs
+++ b/myceliald/src/runtime.rs
@@ -75,6 +75,7 @@ fn setup_registry<S: SectionChannel>() -> Registry<S> {
         ),
         ("file_source", constructors::file::source_ctor),
         ("file_destination", constructors::file::destination_ctor),
+        ("dir_source", constructors::dir::source_ctor),
         //("sqlite_physical_replication_destination", sqlite_physical_replication::destination::constructor),
         //("sqlite_physical_replication_source", sqlite_physical_replication::source::constructor),
     ];

--- a/pipe/section/section_impls/dir/Cargo.toml
+++ b/pipe/section/section_impls/dir/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "dir"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+section = { path = "../../" }
+tokio = { version = "1", features = ["full"] }
+tokio-stream = { version = "0.1", features = ["fs"] }
+notify = { version = "6", default-features = false, features = ["macos_kqueue"] }
+regex = "1.10.4"
+tracing = "0.1.40"
+
+[dev-dependencies]
+clap = { version = "4", features = ["derive"]}
+stub = { path = "../stub" }
+tokio-util = "0.7"

--- a/pipe/section/section_impls/dir/examples/list_dir.rs
+++ b/pipe/section/section_impls/dir/examples/list_dir.rs
@@ -1,0 +1,61 @@
+//! List directory with applied filters
+//! This example outputs dataframe with full paths
+
+use clap::Parser;
+use dir::source::DirSource;
+use section::{
+    dummy::DummySectionChannel, futures::SinkExt, message::Chunk, pretty_print::pretty_print,
+    section::Section, SectionError, SectionMessage,
+};
+use std::{path::PathBuf, time::Duration};
+use stub::Stub;
+use tokio::sync::mpsc::channel;
+use tokio_util::sync::PollSender;
+
+#[derive(Debug, Parser)]
+struct Cli {
+    #[clap(short, long)]
+    dir_path: PathBuf,
+    #[clap(short, long)]
+    pattern: Option<String>,
+    #[clap(short, long)]
+    start_after: Option<String>,
+}
+
+#[tokio::main]
+async fn main() {
+    let cli = Cli::parse();
+    println!("cli: {cli:?}");
+    let source = DirSource::new(
+        cli.dir_path,
+        cli.pattern,
+        cli.start_after,
+        Duration::from_secs(3),
+    )
+    .unwrap();
+    println!("source: {source:?}");
+
+    let (tx, mut rx) = channel(1);
+    let tx = PollSender::new(tx).sink_map_err(|_| "send error".into());
+
+    tokio::spawn(async move {
+        source
+            .start(
+                Stub::<SectionMessage, SectionError>::new(),
+                Box::new(tx),
+                DummySectionChannel::new(),
+            )
+            .await
+            .unwrap();
+    });
+    while let Some(mut msg) = rx.recv().await {
+        println!("message: {msg:?}");
+        while let Some(chunk) = msg.next().await.unwrap() {
+            match chunk {
+                Chunk::DataFrame(df) => println!("{}", pretty_print(&*df)),
+                Chunk::Byte(_bin) => println!("bin"),
+            };
+        }
+        msg.ack().await;
+    }
+}

--- a/pipe/section/section_impls/dir/src/lib.rs
+++ b/pipe/section/section_impls/dir/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod source;

--- a/pipe/section/section_impls/dir/src/source.rs
+++ b/pipe/section/section_impls/dir/src/source.rs
@@ -145,8 +145,7 @@ impl DirSource {
                         entries.push(entry);
                     }
                     // sort in reverse order to preserve proper order after pushing values to front of vec deque
-                    entries
-                        .sort_by_key(|right| std::cmp::Reverse(right.file_name()));
+                    entries.sort_by_key(|right| std::cmp::Reverse(right.file_name()));
                     entries
                         .into_iter()
                         .for_each(|entry| self.walk_stack.push(entry));

--- a/pipe/section/section_impls/dir/src/source.rs
+++ b/pipe/section/section_impls/dir/src/source.rs
@@ -1,0 +1,259 @@
+#![allow(unused)]
+use regex::Regex;
+use section::{
+    command_channel::{Command, SectionChannel, WeakSectionChannel},
+    futures::{self, FutureExt, Sink, SinkExt, Stream, StreamExt},
+    message::{Ack, Chunk, Column, DataFrame, DataType, Message, Next, ValueView},
+    section::Section,
+    state::State,
+    SectionError, SectionFuture, SectionMessage,
+};
+use std::pin::pin;
+use std::{
+    any::Any,
+    collections::VecDeque,
+    path::{Path, PathBuf},
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::Duration,
+};
+use tokio::fs::{read_dir, DirEntry};
+use tokio_stream::wrappers::ReadDirStream;
+
+pub type Result<T, E = SectionError> = core::result::Result<T, E>;
+
+struct DirSourceMessage {
+    origin: Arc<str>,
+    path: Option<Arc<str>>,
+    ack: Option<Ack>,
+}
+
+impl DirSourceMessage {
+    fn new(origin: Arc<str>, ack: Ack) -> Self {
+        let path = Arc::clone(&origin);
+        Self {
+            origin,
+            path: Some(path),
+            ack: Some(ack),
+        }
+    }
+}
+
+impl std::fmt::Debug for DirSourceMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DirSourceMessage")
+            .field("origin", &self.origin.as_ref())
+            .field("path", &self.path.as_ref())
+            .field("ack", &self.ack.as_ref().map(|_| "Some").unwrap_or("None"))
+            .finish()
+    }
+}
+
+#[derive(Debug)]
+struct PathDataFrame {
+    path: Arc<str>,
+}
+
+impl DataFrame for PathDataFrame {
+    fn columns(&self) -> Vec<Column<'_>> {
+        vec![Column::new(
+            "path",
+            DataType::Str,
+            Box::new(std::iter::once(ValueView::Str(self.path.as_ref()))),
+        )]
+    }
+}
+
+impl Message for DirSourceMessage {
+    fn ack(&mut self) -> Ack {
+        self.ack.take().unwrap_or(Box::pin(async {}))
+    }
+
+    fn next(&mut self) -> Next<'_> {
+        let chunk = self
+            .path
+            .take()
+            .map(|path| Chunk::DataFrame(Box::new(PathDataFrame { path })));
+        Box::pin(async move { Ok(chunk) })
+    }
+
+    fn origin(&self) -> &str {
+        self.origin.as_ref()
+    }
+}
+
+#[derive(Debug)]
+pub struct DirSource {
+    path: PathBuf,
+    pattern: Option<Regex>,
+    start_after: Option<String>,
+    walk_stack: Vec<DirEntry>,
+    stream_mode: (),
+    interval: Duration,
+}
+
+impl DirSource {
+    pub fn new(
+        path: PathBuf,
+        pattern: Option<String>,
+        start_after: Option<String>,
+        interval: Duration,
+    ) -> Result<Self> {
+        let pattern = match pattern {
+            Some(s) => Some(Regex::try_from(s)?),
+            None => None,
+        };
+        Ok(Self {
+            path,
+            pattern,
+            start_after,
+            walk_stack: vec![],
+            stream_mode: (),
+            interval,
+        })
+    }
+
+    // initiate walking stack
+    async fn init_walk_stack(&mut self) -> Result<()> {
+        let mut read_dir = tokio::fs::read_dir(self.path.as_path()).await?;
+        while let Some(entry) = read_dir.next_entry().await? {
+            self.walk_stack.push(entry);
+        }
+        // sort in reverse order
+        self.walk_stack
+            .sort_by_key(|right| std::cmp::Reverse(right.path()));
+        Ok(())
+    }
+
+    // walk path
+    // apply pattern/start_after filters
+    // sort result, since `read_dir` is not guaranteed to be sorted
+    async fn walk_path(&mut self) -> Result<Option<String>> {
+        loop {
+            let entry = match self.walk_stack.pop() {
+                Some(entry) => entry,
+                None => return Ok(None),
+            };
+            let entry_type = entry.file_type().await?;
+            match (entry_type.is_dir(), entry_type.is_file()) {
+                (true, _) => {
+                    let mut entries = vec![];
+                    let mut entry_stream = ReadDirStream::new(read_dir(entry.path()).await?);
+                    while let Some(maybe_entry) = entry_stream.next().await {
+                        let entry = maybe_entry?;
+                        entries.push(entry);
+                    }
+                    // sort in reverse order to preserve proper order after pushing values to front of vec deque
+                    entries
+                        .sort_by_key(|right| std::cmp::Reverse(right.file_name()));
+                    entries
+                        .into_iter()
+                        .for_each(|entry| self.walk_stack.push(entry));
+                }
+                (_, true) => {
+                    let fname = entry.path();
+                    let rel_fname = fname
+                        .strip_prefix(self.path.as_path())?
+                        .to_string_lossy()
+                        .to_string();
+                    let fname = fname.to_string_lossy().to_string();
+                    if self.start_after.as_ref() >= Some(&fname) {
+                        tracing::debug!("{fname} less than `start_after`, filtered");
+                        continue;
+                    }
+                    if self
+                        .pattern
+                        .as_ref()
+                        .map(|pattern| !pattern.is_match(&rel_fname))
+                        .unwrap_or(false)
+                    {
+                        tracing::debug!("{fname} doesn't match pattern, filtered");
+                        continue;
+                    }
+                    // updating start_after filter here
+                    self.start_after = Some(fname);
+                    // FIXME: converting pathbuf to string, good enough for now, but incorrect in general
+                    return Ok(Some(entry.path().to_string_lossy().to_string()));
+                }
+                _ => (),
+            }
+        }
+    }
+}
+
+const START_AFTER_KEY: &str = "start_after";
+const PATH_KEY: &str = "path";
+
+impl<Input, Output, SectionChan> Section<Input, Output, SectionChan> for DirSource
+where
+    Input: Stream<Item = SectionMessage> + Send + 'static,
+    Output: Sink<SectionMessage, Error = SectionError> + Send + 'static,
+    SectionChan: SectionChannel + Send + 'static,
+{
+    type Error = SectionError;
+    type Future = SectionFuture;
+
+    fn start(
+        mut self,
+        _input: Input,
+        output: Output,
+        mut section_channel: SectionChan,
+    ) -> Self::Future {
+        Box::pin(async move {
+            let mut output = pin!(output);
+            let mut interval = tokio::time::interval(self.interval);
+            let mut state = section_channel
+                .retrieve_state()
+                .await?
+                .unwrap_or(State::new());
+
+            // check if state needs to be reset
+            // reset can happen if:
+            // - section path was changed
+            match state.get::<String>(PATH_KEY)? {
+                Some(ref path) if PathBuf::from(path) != self.path => {
+                    tracing::info!("path changed, resetting state");
+                    state = State::new();
+                    section_channel.store_state(state.clone()).await?;
+                }
+                _ => (),
+            };
+            state.set(PATH_KEY, self.path.to_string_lossy().to_string())?;
+            self.start_after = state.get(START_AFTER_KEY)?.unwrap_or(self.start_after);
+
+            loop {
+                futures::select! {
+                    _ = interval.tick().fuse() => {
+                        tracing::info!("tick");
+                        self.init_walk_stack().await?;
+                        while let Some(file) = self.walk_path().await? {
+                            let weak_chan = section_channel.weak_chan();
+                            let file = Arc::from(file);
+                            let file_clone: Box<dyn Any + Send> = Box::new(Arc::clone(&file));
+                            let ack: Ack = Box::pin(async move { weak_chan.ack(file_clone).await; });
+                            let message: SectionMessage = Box::new(DirSourceMessage::new(file, ack));
+                            output.send(message).await?;
+                        }
+                    },
+                    cmd = section_channel.recv().fuse() => {
+                        match cmd? {
+                            Command::Stop => return Ok(()),
+                            Command::Ack(ack) => {
+                                match ack.downcast_ref::<Arc<str>>() {
+                                    Some(acked) => {
+                                        tracing::debug!("ack for '{acked}' received");
+                                        state.set(START_AFTER_KEY, acked.to_string());
+                                        section_channel.store_state(state.clone()).await?;
+                                    },
+                                    None => Err("failed to downcast Ack message")?
+                                };
+                            },
+                            _ => (),
+                        }
+                    }
+                }
+            }
+        })
+    }
+}

--- a/server/Makefile
+++ b/server/Makefile
@@ -15,7 +15,7 @@ clean:
 
 .PHONY: dev
 dev:
-	RUST_LOG=$(RUST_LOG) cargo-watch -q -c \
+	cargo-watch -q -c \
 		-i mycelial.db \
 		-s 'cargo run -- --token=tken --database-url=sqlite://mycelial.db'
 


### PR DESCRIPTION
Add simple directory section, which allows ordered traversal through directory tree.
Supports notion of `pattern` (regex-defined match) and `start_after`.
Both `pattern` and `start_after` are checked against relative path of a file, i.e. directory prefix is stripped.